### PR TITLE
URPのShadowCoordの計算をvertからfragに移動

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_macro.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_macro.hlsl
@@ -296,9 +296,11 @@
         #if defined(SHADOWS_SCREEN) || defined(_MAIN_LIGHT_SHADOWS_SCREEN)
             #define LIL_TRANSFER_SHADOW(vi,uv,o)        o.shadowCoord = ComputeScreenPos(vi.positionCS);
         #else
-            #define LIL_TRANSFER_SHADOW(vi,uv,o)        o.shadowCoord = TransformWorldToShadowCoord(vi.positionWS);
+            #define LIL_TRANSFER_SHADOW(vi,uv,o)        o.shadowCoord = float4(vi.positionWS, 1.0);
         #endif
-        #define LIL_LIGHT_ATTENUATION(atten,i)      float atten = MainLightRealtimeShadow(i.shadowCoord)
+        #define LIL_LIGHT_ATTENUATION(atten,i) \
+            float4 shadowCoord = TransformWorldToShadowCoord(i.shadowCoord); \
+            float atten = MainLightRealtimeShadow(shadowCoord)
     #else
         #define LIL_SHADOW_COORDS(idx)
         #define LIL_TRANSFER_SHADOW(vi,uv,o)


### PR DESCRIPTION
URPのCascadeShadowが有効な時にReceiveShadowが正しく動作しない問題があったので以下の対応を行いました。
* ShadowCoordの計算をvertからfragに移動

他に影響がないかすべて確認したわけではないので、ご確認いただけると幸いです。
また、shadowCoord計算をfragに移動したことによる負荷向上も考慮していないので、こちらもご確認いただければと思います。