### PR TITLE
fix avatar encryption shadow caster issue

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_pass_shadowcaster.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_shadowcaster.hlsl
@@ -12,6 +12,10 @@ struct appdata
     #if LIL_RENDER > 0
         float2 uv           : TEXCOORD0;
     #endif
+    #if defined(LIL_FEATURE_ENCRYPTION)
+        float2 uv6          : TEXCOORD6;
+        float2 uv7          : TEXCOORD7;
+    #endif
     UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
@@ -41,6 +45,12 @@ v2f vert(appdata input)
     UNITY_SETUP_INSTANCE_ID(input);
     UNITY_TRANSFER_INSTANCE_ID(input, output);
     UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+    
+    //----------------------------------------------------------------------------------------------------------------------
+    // Encryption
+    #if defined(LIL_FEATURE_ENCRYPTION)
+        input.positionOS = vertexDecode(input.positionOS, input.normalOS, input.uv6, input.uv7);
+    #endif
 
     LIL_TRANSFER_SHADOW_CASTER(input,output);
     #if LIL_RENDER > 0


### PR DESCRIPTION
without vertex deocde in the shadow caster, shadows appear strange when using avatar encryption.