### PR TITLE
fix error in use install/update UPM when exists SettingFolder

### DIFF
--- a/Assets/lilToon/Editor/lilStartup.cs
+++ b/Assets/lilToon/Editor/lilStartup.cs
@@ -22,6 +22,31 @@ namespace lilToon
             lilToonInspector.InitializeLanguage();
 
             // Initialize
+            if(lilToonInspector.isUPM)
+            {
+                StreamReader csr = new StreamReader(shaderCommonPath);
+                string cs = csr.ReadToEnd();
+                csr.Close();
+                cs = cs.Replace(
+                    "#include \"../../../lilToonSetting/lil_setting.hlsl\"",
+                    "#include \"Assets/lilToonSetting/lil_setting.hlsl\"");
+                StreamWriter csw = new StreamWriter(shaderCommonPath,false);
+                csw.Write(cs);
+                csw.Close();
+            }
+            else
+            {
+                StreamReader csr = new StreamReader(shaderCommonPath);
+                string cs = csr.ReadToEnd();
+                csr.Close();
+                cs = cs.Replace(
+                    "#include \"Assets/lilToonSetting/lil_setting.hlsl\"",
+                    "#include \"../../../lilToonSetting/lil_setting.hlsl\"");
+                StreamWriter csw = new StreamWriter(shaderCommonPath,false);
+                csw.Write(cs);
+                csw.Close();
+            }
+
             if(!Directory.Exists(settingFolderPath))
             {
                 // Setting Folder
@@ -34,30 +59,6 @@ namespace lilToon
                     sw.Close();
                     AssetDatabase.ImportAsset(shaderSettingHLSLPath);
                     Debug.Log("Generate setting hlsl file");
-                }
-                if(lilToonInspector.isUPM)
-                {
-                    StreamReader csr = new StreamReader(shaderCommonPath);
-                    string cs = csr.ReadToEnd();
-                    csr.Close();
-                    cs = cs.Replace(
-                        "#include \"../../../lilToonSetting/lil_setting.hlsl\"",
-                        "#include \"Assets/lilToonSetting/lil_setting.hlsl\"");
-                    StreamWriter csw = new StreamWriter(shaderCommonPath,false);
-                    csw.Write(cs);
-                    csw.Close();
-                }
-                else
-                {
-                    StreamReader csr = new StreamReader(shaderCommonPath);
-                    string cs = csr.ReadToEnd();
-                    csr.Close();
-                    cs = cs.Replace(
-                        "#include \"Assets/lilToonSetting/lil_setting.hlsl\"",
-                        "#include \"../../../lilToonSetting/lil_setting.hlsl\"");
-                    StreamWriter csw = new StreamWriter(shaderCommonPath,false);
-                    csw.Write(cs);
-                    csw.Close();
                 }
 
                 // Editor


### PR DESCRIPTION
## 概要

すでに利用中の場合などで`Assets/lilToonSetting`が存在する時、
unitypackage版からの切り替えやUPM版の更新などでリポジトリからUPMで取得した場合に、
`lilStartup.cs`のInitializeによる`lil_common.hlsl`の書き換えが行われず、
`lil_setting.hlsl`が参照できない事によりシェーダーエラーが発生します


## 再現手順

1. Unitypackage版またはUPM版の導入を実施し、`Assets/lilToonSetting/lil_setting.hlsl`が生成された事を確認
2. 一旦Removeしてから再度インストールを実施
3. liltoonを当てたマテリアルがエラーマテリアルとなる事を確認

## 改善提案

* UnityPackage版からUPM版の切り替え時や、UPM版の更新/再インストール時にも`lil_common.hlsl`の書き換えが必要
* 当該の処理を`if(!Directory.Exists(settingFolderPath))`の外に置く事を提案します
  * ※Unity起動時や何らかのコンパイルが走ったあとなどに都度実行されてしまうため、より良い対応があれば適宜補正お願いいたします

## 関連ログ
```
Shader error in 'Hidden/lilToonOutline': failed to open source file: '../../../lilToonSetting/lil_setting.hlsl'
Shader error in 'Hidden/lilToonTransparentOutline': failed to open source file: '../../../lilToonSetting/lil_setting.hlsl'
Shader error in 'lilToon': failed to open source file: '../../../lilToonSetting/lil_setting.hlsl'
Shader error in 'Hidden/lilToonGem': failed to open source file: '../../../lilToonSetting/lil_setting.hlsl'
Shader error in 'Hidden/lilToonGem': failed to open source file: '../../../lilToonSetting/lil_setting.hlsl' at /Unity/--My Project Name--/Library/PackageCache/jp.lilxyzw.liltoon@76d95cc476/Shader/Includes/lil_common.hlsl(5) (on d3d11)
```