### PR TITLE
Import System for rsp startup check

### DIFF
--- a/Assets/lilToon/Editor/lilStartup.cs
+++ b/Assets/lilToon/Editor/lilStartup.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEngine.Networking;
+using System;
 using System.IO;
 using System.Collections;
 using System.Reflection;


### PR DESCRIPTION
Cannot reference Environment without System, so the startup check for RSP fails. 