### PR TITLE
AlphaMaskの柔軟性向上

### DIFF
--- a/Assets/lilToon/BaseShaderResources/ltspass_baker.lilinternal
+++ b/Assets/lilToon/BaseShaderResources/ltspass_baker.lilinternal
@@ -47,7 +47,7 @@ Shader "Hidden/ltsother_baker"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 
@@ -127,7 +127,13 @@ Shader "Hidden/ltsother_baker"
                     float4 col = LIL_SAMPLE_2D(_MainTex,sampler_MainTex,input.uv0);
                     float alphaMask = LIL_SAMPLE_2D(_AlphaMask,sampler_MainTex,input.uv0).r;
                     alphaMask = saturate(alphaMask * _AlphaMaskScale + _AlphaMaskValue);
-                    col.a = _AlphaMaskMode == 1 ? alphaMask : col.a * alphaMask;
+                    switch(_AlphaMaskMode){
+                        case 0: break;
+                        case 1: col.a = alphaMask; break;
+                        case 2: col.a = col.a * alphaMask; break;
+                        case 3: col.a = saturate(col.a + alphaMask); break;
+                        case 4: col.a = saturate(col.a - alphaMask); break;
+                    }
                 #elif defined(_NORMAL_DXGL)
                     float4 col = LIL_SAMPLE_2D(_MainTex,sampler_MainTex,input.uv0);
                     col.g = 1.0 - col.g;

--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -88,7 +88,7 @@
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Editor/Resources/lang.txt
+++ b/Assets/lilToon/Editor/Resources/lang.txt
@@ -186,6 +186,8 @@ sAlphaMaskWarnOpaque	If you want to use Alpha Mask, you need to change the "Rend
 sAlphaMaskModeNone	None	None	None	None	None
 sAlphaMaskModeReplace	Replace	置き換え	Replace	Replace	Replace
 sAlphaMaskModeMul	Multiply	乗算	Multiply	Multiply	Multiply
+sAlphaMaskModeAdd	Add	加算	Add	Add	Add
+sAlphaMaskModeSub	Subtract	減算	Subtract	Subtract	Subtract
 sShadowSetting	Shadow	影設定	그림자 설정	阴影设置	陰影設置
 sShadowTips	You can set the color and range of the shadow.	影の色や範囲の設定ができます	그림자의 색상과 범위를 설정할 수 있습니다	你可以设置阴影的颜色和范围。	你可以設置陰影的顏色和範圍。
 sShadow	Shadow	影	그림자	阴影	陰影

--- a/Assets/lilToon/Editor/lilInspector.cs
+++ b/Assets/lilToon/Editor/lilInspector.cs
@@ -4495,6 +4495,7 @@ namespace lilToon
                 {
                     EditorGUILayout.BeginVertical(boxInnerHalf);
                     m_MaterialEditor.TexturePropertySingleLine(alphaMaskContent, alphaMask);
+                    m_MaterialEditor.TextureScaleOffsetProperty(alphaMask);
 
                     bool invertAlphaMask = alphaMaskScale.floatValue < 0;
                     float transparency = alphaMaskValue.floatValue - (invertAlphaMask ? 1.0f : 0.0f);

--- a/Assets/lilToon/Editor/lilLanguageManager.cs
+++ b/Assets/lilToon/Editor/lilLanguageManager.cs
@@ -145,7 +145,7 @@ namespace lilToon
         {
             sCullModes                      = BuildParams(GetLoc("sCullMode"), GetLoc("sCullModeOff"), GetLoc("sCullModeFront"), GetLoc("sCullModeBack"));
             sBlendModes                     = BuildParams(GetLoc("sBlendMode"), GetLoc("sBlendModeNormal"), GetLoc("sBlendModeAdd"), GetLoc("sBlendModeScreen"), GetLoc("sBlendModeMul"));
-            sAlphaMaskModes                 = BuildParams(GetLoc("sAlphaMask"), GetLoc("sAlphaMaskModeNone"), GetLoc("sAlphaMaskModeReplace"), GetLoc("sAlphaMaskModeMul"));
+            sAlphaMaskModes                 = BuildParams(GetLoc("sAlphaMask"), GetLoc("sAlphaMaskModeNone"), GetLoc("sAlphaMaskModeReplace"), GetLoc("sAlphaMaskModeMul"), GetLoc("sAlphaMaskModeAdd"), GetLoc("sAlphaMaskModeSub"));
             blinkSetting                    = BuildParams(GetLoc("sBlinkStrength"), GetLoc("sBlinkType"), GetLoc("sBlinkSpeed"), GetLoc("sBlinkOffset"));
             sDistanceFadeSetting            = BuildParams(GetLoc("sStartDistance"), GetLoc("sEndDistance"), GetLoc("sStrength"), GetLoc("sBackfaceForceShadow"));
             sDissolveParams                 = BuildParams(GetLoc("sDissolveMode"), GetLoc("sDissolveModeNone"), GetLoc("sDissolveModeAlpha"), GetLoc("sDissolveModeUV"), GetLoc("sDissolveModePosition"), GetLoc("sDissolveShape"), GetLoc("sDissolveShapePoint"), GetLoc("sDissolveShapeLine"), GetLoc("sBorder"), GetLoc("sBlur"));

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -436,7 +436,7 @@
 // Alpha Mask
 #if !defined(OVERRIDE_ALPHAMASK)
     #if defined(LIL_FEATURE_AlphaMask)
-        #define LIL_SAMPLE_AlphaMask alphaMask = LIL_SAMPLE_2D(_AlphaMask, sampler_MainTex, fd.uvMain).r
+        #define LIL_SAMPLE_AlphaMask alphaMask = LIL_SAMPLE_2D_ST(_AlphaMask, sampler_MainTex, fd.uvMain).r
     #else
         #define LIL_SAMPLE_AlphaMask
     #endif
@@ -447,7 +447,13 @@
             float alphaMask = 1.0; \
             LIL_SAMPLE_AlphaMask; \
             alphaMask = saturate(alphaMask * _AlphaMaskScale + _AlphaMaskValue); \
-            fd.col.a = _AlphaMaskMode == 1 ? alphaMask : fd.col.a * alphaMask; \
+            switch(_AlphaMaskMode){ \
+            case 0: break; \
+            case 1: fd.col.a = alphaMask; break; \
+            case 2: fd.col.a = fd.col.a * alphaMask; break; \
+            case 3: fd.col.a = saturate(fd.col.a + alphaMask); break; \
+            case 4: fd.col.a = saturate(fd.col.a - alphaMask); break; \
+            } \
         }
 #endif
 

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -379,6 +379,7 @@ CBUFFER_START(UnityPerMaterial)
         float   _Main3rdDissolveNoiseStrength;
     #endif
     #if defined(LIL_MULTI_INPUTS_ALPHAMASK)
+        float4  _AlphaMask_ST;
         float   _AlphaMaskScale;
         float   _AlphaMaskValue;
     #endif

--- a/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
@@ -292,6 +292,7 @@ float   _MonochromeLighting;
     #endif
 #endif
 #if defined(LIL_FEATURE_ALPHAMASK)
+    float4  _AlphaMask_ST;
     float   _AlphaMaskScale;
     float   _AlphaMaskValue;
 #endif

--- a/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
@@ -292,6 +292,7 @@ float   _MonochromeLighting;
     #endif
 #endif
 #if defined(LIL_FEATURE_ALPHAMASK)
+    float4  _AlphaMask_ST;
     float   _AlphaMaskScale;
     float   _AlphaMaskValue;
 #endif

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -92,7 +92,7 @@ Shader "lilToon"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonCutout"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonCutoutOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonFur"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonFurCutout"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonFurTwoPass"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonGem"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonOnePassTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonOverlay"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonRefraction"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonRefractionBlur"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellation"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationCutout"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -92,7 +92,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTwoPassTransparent"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -92,7 +92,7 @@ Shader "_lil/lilToonMulti"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonMultiFur"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonMultiGem"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonMultiOutline"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -92,7 +92,7 @@ Shader "Hidden/lilToonMultiRefraction"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 

--- a/Assets/lilToon/Shader/ltspass_baker.shader
+++ b/Assets/lilToon/Shader/ltspass_baker.shader
@@ -47,7 +47,7 @@ Shader "Hidden/ltsother_baker"
         //----------------------------------------------------------------------------------------------------------------------
         // Alpha Mask
         [lilEnumLabel]  _AlphaMaskMode              ("AlphaMask|", Int) = 0
-        [NoScaleOffset] _AlphaMask                  ("AlphaMask", 2D) = "white" {}
+                        _AlphaMask                  ("AlphaMask", 2D) = "white" {}
                         _AlphaMaskScale             ("Scale", Float) = 1
                         _AlphaMaskValue             ("Offset", Float) = 0
 


### PR DESCRIPTION
* repeatする素材を用いてAlphaMaskを上書きできるように、AlphaMaskのScaleとOffsetを有効化。
* Mainで不透過とした部分、透過とした部分のみ上書きできるように、AlphaMaskModeに加算と減算を追加。

一部を不透過としながら透過した部分にrepeat素材を用いることができるようになります。
![image_073_0010 (小)](https://user-images.githubusercontent.com/81757117/182612739-26d91610-41f2-4660-8f8d-d6e24eb380fc.png)

