### PR TITLE
Fix error in VRCSDK3 World

### DIFF
--- a/Assets/lilToon/External/Editor/VRChatModule.cs
+++ b/Assets/lilToon/External/Editor/VRChatModule.cs
@@ -4,8 +4,10 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
+#if !UDON
+using VRC.SDK3.Avatars.Components;
+#endif
 
 namespace lilToon
 {


### PR DESCRIPTION
1.3.4にて追加された`Assets/lilToon/External/Editor/VRChatModule.cs`にて、`VRC.SDK3.Avatars`を参照していますが、
こちらSDK3 World側には存在しないため、ワールド用のプロジェクトではエラーを吐く様になっていました

### エラー抜粋
```
Assets\lilToon\External\Editor\VRChatModule.cs(7,16): error CS0234: The type or namespace name 'Avatars' does not exist in the namespace 'VRC.SDK3' (are you missing an assembly reference?)
```

### 再現手順
- 新規プロジェクトにVRCSDK3-Worldをインポートし、その後lilToon1.3.4をインポート

### 対応案
他の対応箇所同様、`#if !UDON`で`using VRC.SDK3.Avatars.Components;`を囲む形での対処を提案します