### PR TITLE
Use versionDefines to detect VRCSDK

### DIFF
--- a/Assets/lilToon/Editor/lilInspector.cs
+++ b/Assets/lilToon/Editor/lilInspector.cs
@@ -3095,7 +3095,7 @@ namespace lilToon
             }
 
 
-            #if VRC_SDK_VRCSDK3 && !UDON
+            #if LILTOON_VRCSDK3_AVATARS
                 EditorGUI.BeginChangeCheck();
                 GUI.enabled = !isLocked;
                 ToggleGUI(GetLoc("sShaderSettingOptimizeInTestBuild"), ref shaderSetting.isOptimizeInTestBuild);
@@ -3308,7 +3308,7 @@ namespace lilToon
 
         private void DrawVRCFallbackGUI(Material material)
         {
-            #if VRC_SDK_VRCSDK2 || VRC_SDK_VRCSDK3 || VRC_SDK_VRCSDK4
+            #if VRC_SDK_VRCSDK2 || LILTOON_VRCSDK3 || VRC_SDK_VRCSDK4
                 edSet.isShowVRChat = lilEditorGUI.Foldout("VRChat", "VRChat", edSet.isShowVRChat);
                 if(edSet.isShowVRChat)
                 {
@@ -3394,7 +3394,7 @@ namespace lilToon
 
         private void DrawOptimizationButton(Material material, bool isnormal)
         {
-            #if VRC_SDK_VRCSDK3 && UDON
+            #if LILTOON_VRCSDK3_WORLDS
                 if(isnormal && lilEditorGUI.EditorButton(GetLoc("sOptimizeForEvents"))) lilMaterialUtils.RemoveUnusedTexture(material);
             #endif
         }
@@ -4186,7 +4186,7 @@ namespace lilToon
                     m_MaterialEditor.RenderQueueField();
                     if((renderingModeBuf >= RenderingMode.Transparent && renderingModeBuf != RenderingMode.FurCutout) || (isMulti && transparentModeMat.floatValue == 2.0f))
                     {
-                        #if VRC_SDK_VRCSDK3 && UDON
+                        #if LILTOON_VRCSDK3_WORLDS
                             if(material.renderQueue <= 2999 && zwrite.floatValue == 1.0f)
                             {
                                 EditorGUILayout.HelpBox(GetLoc("sHelpTransparentForWorld"),MessageType.Warning);

--- a/Assets/lilToon/Editor/lilMaterialUtils.cs
+++ b/Assets/lilToon/Editor/lilMaterialUtils.cs
@@ -327,7 +327,7 @@ namespace lilToon
 
         private static void FixTransparentRenderQueue(Material material, RenderingMode renderingMode)
         {
-            #if VRC_SDK_VRCSDK3 && UDON
+            #if LILTOON_VRCSDK3_WORLDS
                 if( renderingMode == RenderingMode.Transparent ||
                     renderingMode == RenderingMode.Refraction ||
                     renderingMode == RenderingMode.RefractionBlur ||

--- a/Assets/lilToon/Editor/lilToon.Editor.asmdef
+++ b/Assets/lilToon/Editor/lilToon.Editor.asmdef
@@ -2,5 +2,22 @@
     "name": "lilToon.Editor",
     "includePlatforms": [
         "Editor"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.avatars",
+            "expression": "",
+            "define": "LILTOON_VRCSDK3_AVATARS"
+        },
+        {
+            "name": "com.vrchat.worlds",
+            "expression": "",
+            "define": "LILTOON_VRCSDK3_WORLDS"
+        },
+        {
+            "name": "com.vrchat.base",
+            "expression": "",
+            "define": "LILTOON_VRCSDK3"
+        }
     ]
 }

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -1305,7 +1305,7 @@ public class lilToonSetting : ScriptableObject
 
         lilToonSetting shaderSetting = null;
         InitializeShaderSetting(ref shaderSetting);
-        #if VRC_SDK_VRCSDK3 && !UDON
+        #if LILTOON_VRCSDK3_AVATARS
             return shaderSetting.isOptimizeInTestBuild && !shaderSetting.isDebugOptimize;
         #else
             return !shaderSetting.isDebugOptimize;

--- a/Assets/lilToon/External/Editor/VRChatModule.cs
+++ b/Assets/lilToon/External/Editor/VRChatModule.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && VRC_SDK_VRCSDK3
+#if UNITY_EDITOR && LILTOON_VRCSDK3
 using UnityEditor;
 using UnityEngine;
 using System;

--- a/Assets/lilToon/External/Editor/lilToon.Editor.External.asmdef
+++ b/Assets/lilToon/External/Editor/lilToon.Editor.External.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.base",
+            "expression": "",
+            "define": "LILTOON_VRCSDK3"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
[VPM]を使用してVRCSDKをインストールすると"versionDefines"を使用したVRCSDK AvatarsまたはWorldsの認識ができるためこれを実装しました。
`VRC_SDK_VRCSDK3 && !UDON`や`VRC_SDK_VRCSDK3 && UDON`が現在使われていますが、将来VRCSDK3のワールドとアバターを同時にプロジェクトに入れられるようになった際に壊れてしまいます。また、VCC beta初期にはこれらが削除されたこともあります(vrchat/packages#8)。そのため"versionDefines"を使用するほうがいいと考えました。

[VPM]: https://vcc.docs.vrchat.com/vpm/