### PR TITLE
アセット更新を止めるシンボル追加

### DIFF
--- a/Assets/lilToon/Editor/lilShaderContainerImporter.cs
+++ b/Assets/lilToon/Editor/lilShaderContainerImporter.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 
 namespace lilToon
 {
+    #if LILTOON_DISABLE_ASSET_MODIFICATION == false
     #if UNITY_2019_4_OR_NEWER
         [ScriptedImporter(0, "lilcontainer")]
         public class lilShaderContainerImporter : ScriptedImporter
@@ -68,6 +69,7 @@ namespace lilToon
             }
         }
     #endif
+    #endif //LILTOON_DISABLE_ASSET_MODIFICATION
 
     public class lilShaderContainer
     {

--- a/Assets/lilToon/Editor/lilStartup.cs
+++ b/Assets/lilToon/Editor/lilStartup.cs
@@ -29,6 +29,7 @@ namespace lilToon
             {
                 File.Create(lilDirectoryManager.startupTempPath);
 
+                #if LILTOON_DISABLE_ASSET_MODIFICATION == false
                 #if !SYSTEM_DRAWING
                     string editorPath = lilDirectoryManager.GetEditorPath();
 
@@ -63,6 +64,7 @@ namespace lilToon
                         AssetDatabase.ImportAsset(editorPath);
                     }
                 #endif
+                #endif //LILTOON_DISABLE_ASSET_MODIFICATION
             }
 
             //------------------------------------------------------------------------------------------------------------------------------

--- a/Assets/lilToon/Editor/lilToonEditorUtils.cs
+++ b/Assets/lilToon/Editor/lilToonEditorUtils.cs
@@ -749,6 +749,7 @@ namespace lilToon
         public static string GetLoc(string value) { return lilLanguageManager.GetLoc(value); }
     }
 
+#if LILTOON_DISABLE_ASSET_MODIFICATION == false
 #if UNITY_2019_3_OR_NEWER
     //------------------------------------------------------------------------------------------------------------------------------
     // Build size optimization
@@ -876,5 +877,6 @@ namespace lilToon
             lilToonSetting.SetShaderSettingAfterBuild();
         }
     }
+#endif //LILTOON_DISABLE_ASSET_MODIFICATION
 }
 #endif


### PR DESCRIPTION
プロジェクトのアセットを問答無用で更新されると困る時もあるのでプリプロセッサーシンボルを追加。

`LILTOON_DISABLE_ASSET_MODIFICATION`

csc.rsp とシェーダー生成、マテリアルアセットの更新を止められるように。シンボルが無ければ従来通りの挙動です。
