### PR TITLE
URP 16.0以前の環境でのMotionVector出力の修正

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
@@ -1650,7 +1650,7 @@ float3 lilGetObjectPosition()
     #define LIL_HDRP_DEEXPOSURE(col)
     #define LIL_HDRP_INVDEEXPOSURE(col)
 
-    #if LIL_SRP_VERSION_GREATER_EQUAL(16, 0)
+    #if LIL_SRP_VERSION_GREATER_EQUAL(12, 0)
         #define LIL_MATRIX_PREV_VP _PrevViewProjMatrix
         float3 lilSelectPreviousPosition(float3 previousPositionOS, float3 positionOS)
         {
@@ -1666,7 +1666,16 @@ float3 lilGetObjectPosition()
         {
             if(unity_MotionVectorsParams.y == 0) return float2(0.0, 0.0);
 
-            positionCS.xy = positionCS.xy / positionCS.w;
+            #if LIL_SRP_VERSION_GREATER_EQUAL(16, 0)
+                positionCS.xy = positionCS.xy / positionCS.w;
+            #else
+                positionCS.xy = (positionCS.xy / LIL_SCREENPARAMS.xy - 0.5) * 2.0;
+
+                #if UNITY_UV_STARTS_AT_TOP
+                    positionCS.y = -positionCS.y;
+                #endif
+            #endif
+
             previousPositionCS.xy = previousPositionCS.xy / previousPositionCS.w;
 
             #if defined(_FOVEATED_RENDERING_NON_UNIFORM_RASTER)


### PR DESCRIPTION
`LIL_V2F_POSITION_CS_NO_JITTER`が定義されていない環境での、MotionVector PassのSV_Positionからの入力への対応を追加

他部分への影響の可能性を減らせるように、LIL_V2F_POSITION_CS_NO_JITTERと同じくURP 16.0で分岐していますが、`_NonJittererdViewProjMatrix`自体はTAAに合わせて`URP 14.0.7`から設定されているようです。

https://github.com/Unity-Technologies/Graphics/blob/2022.2/staging/Packages/com.unity.render-pipelines.universal/Runtime/Passes/MotionVectorRenderPass.cs