### PR TITLE
fix: workaround unity bug where UV channels are incorrectly stripped

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Misc.meta
+++ b/Assets/lilToon/CustomShaderResources/Misc.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b800294f0600ca24fabd672f80d0b54e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/lilToon/CustomShaderResources/Misc/ReferenceUVs.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Misc/ReferenceUVs.lilblock
@@ -1,0 +1,58 @@
+﻿Pass
+        {
+            Tags { "LightMode" = "Never" }
+            
+            HLSLPROGRAM
+// Unity strips unused UV channels from meshes; unfortunately, in 2022.3.13f1, Unity fails to detect that UV channels
+// are used when they are referenced from a pass included via `UsePass`. This fake pass is #included directly into
+// each shader to work around this; because this has an invalid lightmode set, it will never actually be executed.
+//
+// Unity bug report ID: IN-60271
+#pragma vertex vert
+#pragma fragment frag
+
+// For some reason, using struct appdata from lil_common_appdata doesn't work as a workaround...
+//#include "Includes/lil_pipeline_brp.hlsl"
+//#include "Includes/lil_common.hlsl"
+//#include "Includes/lil_common_appdata.hlsl"
+
+
+            struct appdata
+            {
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float2 uv3 : TEXCOORD3;
+                
+                float2 uv4 : TEXCOORD4;
+                float2 uv5 : TEXCOORD5;
+                float2 uv6 : TEXCOORD6;
+                float2 uv7 : TEXCOORD7;
+                
+
+                float4 pos : POSITION;
+            };
+
+            struct v2f
+            {
+                float4 pos : POSITION;
+                float4 col : TEXCOORD0;
+            };
+
+            struct v2f vert(struct appdata input)
+            {
+                struct v2f output;
+                // Don't actually render to the screen, but pass UV-derived data all the way down to the fragment
+                // shader so it shows up as an input in the compiled shader program.
+                output.pos = float4(0,0,0,1);
+                output.col = float4(input.uv, input.uv1) + float4(input.uv2, input.uv3)
+                  + float4(input.uv4, input.uv5) + float4(input.uv6, input.uv7);
+                return output;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return i.col;
+            }
+            ENDHLSL
+        }

--- a/Assets/lilToon/CustomShaderResources/Misc/ReferenceUVs.lilblock.meta
+++ b/Assets/lilToon/CustomShaderResources/Misc/ReferenceUVs.lilblock.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04745f0b0223a104c8fe768ed5e2f57a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/lilToon/Editor/lilShaderContainerImporter.cs
+++ b/Assets/lilToon/Editor/lilShaderContainerImporter.cs
@@ -140,7 +140,7 @@ namespace lilToon
         private const string LIL_LIGHTMODE_URP_9_FORWARD_0  = "SRPDefaultUnlit";
         private const string LIL_LIGHTMODE_URP_9_FORWARD_1  = "UniversalForward";
         private const string LIL_LIGHTMODE_URP_9_FORWARD_2  = "UniversalForwardOnly";
-
+        
         private const string csdShaderNameTag                   = "ShaderName";
         private const string csdEditorNameTag                   = "EditorName";
         private const string csdReplaceTag                      = "Replace";
@@ -176,6 +176,8 @@ namespace lilToon
         private static string insertUsePassPre = "";
         private static string insertUsePassPost = "";
 
+        private static string insertUsePassReference = "";
+
         private static PackageVersionInfos version = new PackageVersionInfos();
         private static int indent = 12;
 
@@ -199,6 +201,9 @@ namespace lilToon
             insertPassPost = "";
             insertUsePassPre = "";
             insertUsePassPost = "";
+            insertUsePassReference = File.ReadAllText(
+                GetCustomShaderResourcesFolderPath() + "/Misc/ReferenceUVs.lilblock"
+            );
             isOrigShaderNameLoaded = false;
             replaces = new Dictionary<string, string>();
 
@@ -236,6 +241,8 @@ namespace lilToon
             ReplaceMultiCompiles(ref insertPassPost, version, indent, false);
             ReplaceMultiCompiles(ref insertUsePassPre, version, indent, false);
             ReplaceMultiCompiles(ref insertUsePassPost, version, indent, false);
+            insertUsePassPost += insertUsePassReference;
+                
             sb.Replace(LIL_INSERT_PASS_PRE,         insertPassPre);
             sb.Replace(LIL_INSERT_PASS_POST,        insertPassPost);
             sb.Replace(LIL_INSERT_USEPASS_PRE,      insertUsePassPre);

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -613,6 +613,61 @@ Shader "lilToon"
         UsePass "Hidden/ltspass_opaque/FORWARD_ADD"
         UsePass "Hidden/ltspass_opaque/SHADOW_CASTER"
         UsePass "Hidden/ltspass_opaque/META"
+Pass
+        {
+            Tags { "LightMode" = "Never" }
+            CGPROGRAM
+// Unity strips unused UV channels from meshes; unfortunately, in 2022.3.13f1, Unity fails to detect that UV channels
+// are used when they are referenced from a pass included via `UsePass`. This fake pass is #included directly into
+// each shader to work around this; because this has an invalid lightmode set, it will never actually be executed.
+//
+// Unity bug report ID: IN-60271
+#pragma vertex vert
+#pragma fragment frag
+
+//#include "Includes/lil_pipeline_brp.hlsl"
+//#include "Includes/lil_common.hlsl"
+//#include "Includes/lil_common_appdata.hlsl"
+
+
+            struct appdata
+            {
+                float2 uv : TEXCOORD0;
+                float2 uv1 : TEXCOORD1;
+                float2 uv2 : TEXCOORD2;
+                float2 uv3 : TEXCOORD3;
+                
+                float2 uv4 : TEXCOORD4;
+                float2 uv5 : TEXCOORD5;
+                float2 uv6 : TEXCOORD6;
+                float2 uv7 : TEXCOORD7;
+                
+
+                float4 pos : POSITION;
+            };
+
+            struct v2f
+            {
+                float4 pos : POSITION;
+                float4 col : TEXCOORD0;
+            };
+
+            struct v2f vert(struct appdata input)
+            {
+                struct v2f output;
+                output.pos = float4(0,0,0,1);
+                output.col = float4(input.uv, input.uv1) + float4(input.uv2, input.uv3);
+                  //+ float4(input.uv4, input.uv5) + float4(input.uv6, input.uv7);
+                //output.col = float4(0,0,0,0);
+                return output;
+            }
+
+            float4 frag(v2f i) : SV_Target
+            {
+                return i.col;
+            }
+            ENDCG
+        }
     }
     Fallback "Unlit/Texture"
 


### PR DESCRIPTION
Unity 2022 does not seem to be able to detect that liltoon reads from
TEXCOORD1 (and later) UV channels when building asset bundles; it
therefore strips these from meshes during VRChat avatar builds.

This change adds a new fake pass to each UsePass-type liltoon shader.
While this pass is never executed (due to having LightMode=Never), it
serves to convince Unity that UV1+ is actually required. This workaround
is quite fragile; it doesn't work using the appdata structure in
lil_common_appdata, so we just open-code the whole thing without using
any includes for now.

Note that I didn't see a way to regenerate all of the built-in shaders
for a check-in; as such, only lts.shader is actually updated with this
change.

Fixes: #130
