### PR TITLE
Add support for masking parts as a bitmap

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -450,6 +450,7 @@
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
@@ -450,6 +450,7 @@
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Editor/lilInspector.cs
+++ b/Assets/lilToon/Editor/lilInspector.cs
@@ -708,6 +708,7 @@ namespace lilToon
         private readonly lilMaterialProperty idMask6        = new lilMaterialProperty("_IDMask6", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMask7        = new lilMaterialProperty("_IDMask7", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMask8        = new lilMaterialProperty("_IDMask8", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskIsBitmap = new lilMaterialProperty("_IDMaskIsBitmap", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMaskIndex1   = new lilMaterialProperty("_IDMaskIndex1", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMaskIndex2   = new lilMaterialProperty("_IDMaskIndex2", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMaskIndex3   = new lilMaterialProperty("_IDMaskIndex3", PropertyBlock.IDMask);
@@ -1298,6 +1299,7 @@ namespace lilToon
                 dissolvePos,
 
                 idMaskFrom,
+                idMaskIsBitmap,
                 idMask1,
                 idMask2,
                 idMask3,
@@ -3053,6 +3055,17 @@ namespace lilToon
                         EditorGUILayout.HelpBox("It is recommended that these properties be set from scripts.", MessageType.Warning);
                         EditorGUILayout.HelpBox("If you want to mask vertex ids 1000 to 1999, set:\r\n_IDMask1 = 1\r\n_IDMaskIndex1 = 1000\r\n_IDMaskIndex2 = 2000", MessageType.Info);
                         LocalizedProperty(idMaskFrom);
+                        try
+                        {
+                            if (idMaskIsBitmap.p != null && idMaskIsBitmap.name != null)
+                            {
+                                LocalizedProperty(idMaskIsBitmap);
+                            }
+                        }
+                        catch (NullReferenceException e)
+                        {
+                        }
+
                         LocalizedProperty(idMask1);
                         LocalizedProperty(idMask2);
                         LocalizedProperty(idMask3);

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -1113,7 +1113,8 @@ public class lilToonSetting : ScriptableObject
             material.HasProperty("_IDMask5") && material.GetFloat("_IDMask5") != 0.0f ||
             material.HasProperty("_IDMask6") && material.GetFloat("_IDMask6") != 0.0f ||
             material.HasProperty("_IDMask7") && material.GetFloat("_IDMask7") != 0.0f ||
-            material.HasProperty("_IDMask8") && material.GetFloat("_IDMask8") != 0.0f
+            material.HasProperty("_IDMask8") && material.GetFloat("_IDMask8") != 0.0f ||
+            material.HasProperty("_IDMaskIsBitmap") && material.GetFloat("_IDMaskIsBitmap") != 0.0f
         ))
         {
             Debug.Log("[lilToon] LIL_FEATURE_IDMASK : " + AssetDatabase.GetAssetPath(material));

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -614,6 +614,7 @@ CBUFFER_START(UnityPerMaterial)
         int     _IDMaskIndex7;
         int     _IDMaskIndex8;
         uint    _IDMaskFrom;
+        uint    _IDMaskIsBitmap;
     #endif
     uint    _Cull;
     #if defined(LIL_MULTI_INPUTS_OUTLINE)

--- a/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
@@ -536,6 +536,7 @@ float   _lilShadowCasterBias;
     int     _IDMaskIndex7;
     int     _IDMaskIndex8;
     uint    _IDMaskFrom;
+    uint    _IDMaskIsBitmap;
 #endif
 uint    _Cull;
 #if !defined(LIL_FUR) && !defined(LIL_REFRACTION) && !defined(LIL_GEM)

--- a/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
@@ -392,7 +392,8 @@ LIL_V2F_TYPE vert(appdata input)
             #endif
             default: idMaskArg = input.vertexID; break;
         }
-        bool idMasked = IDMask(idMaskArg,idMaskIndices,idMaskFlags);
+        _IDMaskIsBitmap = round(_IDMaskIsBitmap);
+        bool idMasked = IDMask(idMaskArg,_IDMaskIsBitmap,idMaskIndices,idMaskFlags);
         #if defined(LIL_V2F_POSITION_CS)
             LIL_V2F_OUT_BASE.positionCS = idMasked ? 0.0/0.0 : LIL_V2F_OUT_BASE.positionCS;
         #endif

--- a/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
@@ -219,7 +219,7 @@ v2g vert(appdata input)
             #endif
             default: idMaskArg = input.vertexID; break;
         }
-        bool idMasked = IDMask(idMaskArg,idMaskIndices,idMaskFlags);
+        bool idMasked = IDMask(idMaskArg,_IDMaskIsBitmask,idMaskIndices,idMaskFlags);
         #if defined(LIL_V2G_POSITION_WS)
             output.positionWS = idMasked ? 0.0/0.0 : output.positionWS;
         #endif

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -454,6 +454,7 @@ Shader "lilToon"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonCutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonCutoutOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonFur"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonFurCutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonFurTwoPass"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonGem"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonOnePassTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonOverlay"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonRefraction"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonRefractionBlur"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellation"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationCutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -454,6 +454,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTwoPassTransparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -454,6 +454,7 @@ Shader "_lil/lilToonMulti"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonMultiFur"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonMultiGem"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonMultiOutline"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -454,6 +454,7 @@ Shader "Hidden/lilToonMultiRefraction"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_cutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_opaque"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_proponly.shader
+++ b/Assets/lilToon/Shader/ltspass_proponly.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_proponly"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_tess_cutout"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_tess_opaque"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_tess_transparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -454,6 +454,7 @@ Shader "Hidden/ltspass_transparent"
         [ToggleUI]      _IDMask6                    ("_IDMask6", Int) = 0
         [ToggleUI]      _IDMask7                    ("_IDMask7", Int) = 0
         [ToggleUI]      _IDMask8                    ("_IDMask8", Int) = 0
+        [ToggleUI]      _IDMaskIsBitmap             ("_IDMaskIsBitmap", Int) = 0
                         _IDMaskIndex1               ("_IDMaskIndex1", Int) = 0
                         _IDMaskIndex2               ("_IDMaskIndex2", Int) = 0
                         _IDMaskIndex3               ("_IDMaskIndex3", Int) = 0


### PR DESCRIPTION
This change adds an _IDMaskIsBitmap field; if true, then the ID value passed in a UV channel (specified by _IDMaskFrom) is interpreted as an 8-bit bitmask corresponding to _IDMask1 through _IDMask8, and _IDMaskIndexes are ignored.