### PR TITLE
Add a mode where IDMask settings mask dissolve instead of just hiding vertices

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -460,6 +460,17 @@
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+        
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
@@ -460,6 +460,16 @@
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Editor/lilInspector.cs
+++ b/Assets/lilToon/Editor/lilInspector.cs
@@ -717,6 +717,15 @@ namespace lilToon
         private readonly lilMaterialProperty idMaskIndex6   = new lilMaterialProperty("_IDMaskIndex6", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMaskIndex7   = new lilMaterialProperty("_IDMaskIndex7", PropertyBlock.IDMask);
         private readonly lilMaterialProperty idMaskIndex8   = new lilMaterialProperty("_IDMaskIndex8", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskControlsDissolve = new lilMaterialProperty("_IDMaskControlsDissolve", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior1   = new lilMaterialProperty("_IDMaskPrior1", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior2   = new lilMaterialProperty("_IDMaskPrior2", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior3   = new lilMaterialProperty("_IDMaskPrior3", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior4   = new lilMaterialProperty("_IDMaskPrior4", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior5   = new lilMaterialProperty("_IDMaskPrior5", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior6   = new lilMaterialProperty("_IDMaskPrior6", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior7   = new lilMaterialProperty("_IDMaskPrior7", PropertyBlock.IDMask);
+        private readonly lilMaterialProperty idMaskPrior8   = new lilMaterialProperty("_IDMaskPrior8", PropertyBlock.IDMask);
 
         private readonly lilMaterialProperty ignoreEncryption   = new lilMaterialProperty("_IgnoreEncryption", PropertyBlock.Encryption);
         private readonly lilMaterialProperty keys               = new lilMaterialProperty("_Keys", PropertyBlock.Encryption);
@@ -1316,6 +1325,15 @@ namespace lilToon
                 idMaskIndex6,
                 idMaskIndex7,
                 idMaskIndex8,
+                idMaskControlsDissolve,
+                idMaskPrior1,
+                idMaskPrior2,
+                idMaskPrior3,
+                idMaskPrior4,
+                idMaskPrior5,
+                idMaskPrior6,
+                idMaskPrior7,
+                idMaskPrior8,
 
                 ignoreEncryption,
                 keys,
@@ -3085,6 +3103,20 @@ namespace lilToon
                         LocalizedProperty(idMaskIndex6);
                         LocalizedProperty(idMaskIndex7);
                         LocalizedProperty(idMaskIndex8);
+                        LocalizedProperty(idMaskControlsDissolve);
+
+                        if (idMaskControlsDissolve.p != null && idMaskControlsDissolve.floatValue > 0.5f)
+                        {
+                            LocalizedProperty(idMaskPrior1);
+                            LocalizedProperty(idMaskPrior2);
+                            LocalizedProperty(idMaskPrior3);
+                            LocalizedProperty(idMaskPrior4);
+                            LocalizedProperty(idMaskPrior5);
+                            LocalizedProperty(idMaskPrior6);
+                            LocalizedProperty(idMaskPrior7);
+                            LocalizedProperty(idMaskPrior8);
+                        }
+                        
                         EditorGUILayout.EndVertical();
                         EditorGUILayout.EndVertical();
                     }
@@ -5942,6 +5974,11 @@ namespace lilToon
         private void LocalizedProperty(MaterialProperty prop, bool shouldCheck = true)
         {
             lilEditorGUI.LocalizedProperty(m_MaterialEditor, prop, shouldCheck);
+        }
+
+        private void LocalizedProperty(lilMaterialProperty prop, bool shouldCheck = true)
+        {
+            if (prop.p != null) LocalizedProperty(prop.p, shouldCheck);
         }
 
         private void LocalizedProperty(MaterialProperty prop, string label, bool shouldCheck = true)

--- a/Assets/lilToon/Shader/Includes/lil_common.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common.hlsl
@@ -80,6 +80,7 @@ struct lilFragData
     float2 ddxMain;
     float2 ddyMain;
     bool isRightHand;
+    bool dissolveActive, dissolveInvert;
 
     // Position
     float3 positionOS;
@@ -158,6 +159,8 @@ lilFragData lilInitFragData()
     fd.ddxMain = 0.0;
     fd.ddyMain = 0.0;
     fd.isRightHand = true;
+    fd.dissolveActive = true;
+    fd.dissolveInvert = false;
 
     fd.positionOS = 0.0;
     fd.positionWS = 0.0;

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -178,7 +178,10 @@
 #endif
 
 #if defined(LIL_V2F_POSITION_OS)
-    #define LIL_UNPACK_POSITION_OS(i,o) o.positionOS = i.positionOS;
+    #define LIL_UNPACK_POSITION_OS(i,o) \
+        o.positionOS = i.positionOSdissolve.xyz; \
+        o.dissolveActive = ((int)round(i.positionOSdissolve.w)) & 1; \
+        o.dissolveInvert = ((int)round(i.positionOSdissolve.w)) & 2;
 #else
     #define LIL_UNPACK_POSITION_OS(i,o)
 #endif

--- a/Assets/lilToon/Shader/Includes/lil_common_frag_alpha.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag_alpha.hlsl
@@ -58,7 +58,19 @@
     BEFORE_DISSOLVE
     #if !defined(LIL_LITE) && defined(LIL_FEATURE_DISSOLVE)
         float dissolveAlpha = 0.0;
-        OVERRIDE_DISSOLVE
+        if (fd.dissolveActive)
+        {
+            float priorAlpha = fd.col.a;
+            fd.col.a = 1.0f;
+            OVERRIDE_DISSOLVE
+            if (fd.dissolveInvert)
+            {
+                fd.col.a = 1.0f - fd.col.a;
+                dissolveAlpha = 1.0f - dissolveAlpha;
+            }
+                        
+            fd.col.a *= priorAlpha;
+        }
     #endif
 
     //------------------------------------------------------------------------------------------------------------------------------

--- a/Assets/lilToon/Shader/Includes/lil_common_functions.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_functions.hlsl
@@ -1214,7 +1214,7 @@ bool IDMask(uint maskInput, bool isBitmask, int indices[8], float flags[8])
         // If only some if the bits flagged against this mask are 1, return 0; this ensures that we only hide a vertex
         // if all of the "parts" it belongs to are hidden. This is useful when dealing with "boundary" polygons between
         // two hidable areas, where we don't want to move only some of the vertices of the polygon.
-        return (enableMask & maskInput) == maskInput; 
+        return maskInput && (enableMask & maskInput) == maskInput; 
     } else {
         float4x4 masks = IDToMeshMask(maskInput,indices);
         return dot(masks[0],float4(flags[0],flags[1],flags[2],flags[3])) + dot(masks[1],float4(flags[4],flags[5],flags[6],flags[7]));

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -569,6 +569,15 @@ CBUFFER_START(UnityPerMaterial)
         float   _IDMask6;
         float   _IDMask7;
         float   _IDMask8;
+        uint    _IDMaskControlsDissolve;
+        float   _IDMaskPrior1;
+        float   _IDMaskPrior2;
+        float   _IDMaskPrior3;
+        float   _IDMaskPrior4;
+        float   _IDMaskPrior5;
+        float   _IDMaskPrior6;
+        float   _IDMaskPrior7;
+        float   _IDMaskPrior8;
     #endif
     float   _lilShadowCasterBias;
     #if defined(LIL_MULTI_INPUTS_OUTLINE)

--- a/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
@@ -481,6 +481,15 @@ float   _AAStrength;
     float   _IDMask6;
     float   _IDMask7;
     float   _IDMask8;
+    uint    _IDMaskControlsDissolve;
+    float   _IDMaskPrior1;
+    float   _IDMaskPrior2;
+    float   _IDMaskPrior3;
+    float   _IDMaskPrior4;
+    float   _IDMaskPrior5;
+    float   _IDMaskPrior6;
+    float   _IDMaskPrior7;
+    float   _IDMaskPrior8;
 #endif
 float   _lilShadowCasterBias;
 

--- a/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
@@ -481,6 +481,15 @@ float   _AAStrength;
     float   _IDMask6;
     float   _IDMask7;
     float   _IDMask8;
+    uint    _IDMaskControlsDissolve;
+    float   _IDMaskPrior1;
+    float   _IDMaskPrior2;
+    float   _IDMaskPrior3;
+    float   _IDMaskPrior4;
+    float   _IDMaskPrior5;
+    float   _IDMaskPrior6;
+    float   _IDMaskPrior7;
+    float   _IDMaskPrior8;
 #endif
 float   _lilShadowCasterBias;
 
@@ -536,6 +545,7 @@ float   _lilShadowCasterBias;
     int     _IDMaskIndex7;
     int     _IDMaskIndex8;
     uint    _IDMaskFrom;
+    uint    _IDMaskIsBitmap;
 #endif
 uint    _Cull;
 #if !defined(LIL_FUR) && !defined(LIL_REFRACTION) && !defined(LIL_GEM)

--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_gem.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_gem.hlsl
@@ -57,7 +57,7 @@
             LIL_VECTOR_INTERPOLATION float4 tangentWS    : TEXCOORD4;
         #endif
         #if defined(LIL_V2F_POSITION_OS)
-            float3 positionOS   : TEXCOORD5;
+            float4 positionOSdissolve   : TEXCOORD5;
         #endif
         LIL_LIGHTCOLOR_COORDS(6)
         LIL_LIGHTDIRECTION_COORDS(7)

--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
@@ -14,7 +14,7 @@
     #define LIL_V2F_POSITION_CS
     #define LIL_V2F_PACKED_TEXCOORD01
     #define LIL_V2F_PACKED_TEXCOORD23
-    #if defined(LIL_V2F_FORCE_POSITION_OS) || defined(LIL_SHOULD_POSITION_OS)
+    #if defined(LIL_V2F_FORCE_POSITION_OS) || defined(LIL_SHOULD_POSITION_OS) || defined(LIL_FEATURE_IDMASK)
         #define LIL_V2F_POSITION_OS
     #endif
     #if defined(LIL_V2F_FORCE_POSITION_WS) || defined(LIL_PASS_FORWARDADD) || defined(LIL_FEATURE_OUTLINE_RECEIVE_SHADOW) || defined(LIL_FEATURE_DISTANCE_FADE) || !defined(LIL_BRP) || defined(LIL_USE_LPPV)
@@ -38,7 +38,7 @@
         float4 uv01         : TEXCOORD0;
         float4 uv23         : TEXCOORD1;
         #if defined(LIL_V2F_POSITION_OS)
-            float3 positionOS   : TEXCOORD2;
+            float4 positionOSdissolve   : TEXCOORD2;
         #endif
         #if defined(LIL_V2F_POSITION_WS)
             float3 positionWS   : TEXCOORD3;
@@ -60,7 +60,7 @@
     #define LIL_V2F_POSITION_CS
     #define LIL_V2F_PACKED_TEXCOORD01
     #define LIL_V2F_PACKED_TEXCOORD23
-    #if defined(LIL_V2F_FORCE_POSITION_OS) || defined(LIL_SHOULD_POSITION_OS)
+    #if defined(LIL_V2F_FORCE_POSITION_OS) || defined(LIL_SHOULD_POSITION_OS) || defined(LIL_FEATURE_IDMASK)
         #define LIL_V2F_POSITION_OS
     #endif
     #if defined(LIL_V2F_FORCE_POSITION_WS) || defined(LIL_SHOULD_POSITION_WS)
@@ -90,7 +90,7 @@
         float4 uv01         : TEXCOORD0;
         float4 uv23         : TEXCOORD1;
         #if defined(LIL_V2F_POSITION_OS)
-            float3 positionOS   : TEXCOORD2;
+            float4 positionOSdissolve   : TEXCOORD2;
         #endif
         #if defined(LIL_V2F_POSITION_WS)
             float3 positionWS   : TEXCOORD3;
@@ -175,7 +175,18 @@ float4 frag(v2f input LIL_VFACE(facing)) : SV_Target
         BEFORE_DISSOLVE
         #if defined(LIL_FEATURE_DISSOLVE) && LIL_RENDER != 0
             float dissolveAlpha = 0.0;
-            OVERRIDE_DISSOLVE
+            if (fd.dissolveActive)
+            {
+                float priorAlpha = fd.col.a;
+                fd.col.a = 1.0f;
+                OVERRIDE_DISSOLVE
+                if (fd.dissolveInvert)
+                {
+                    fd.col.a = 1.0f - fd.col.a;
+                }
+                
+                fd.col.a *= priorAlpha;
+            }
         #endif
 
         //------------------------------------------------------------------------------------------------------------------------------
@@ -274,7 +285,18 @@ float4 frag(v2f input LIL_VFACE(facing)) : SV_Target
         BEFORE_DISSOLVE
         #if defined(LIL_FEATURE_DISSOLVE) && LIL_RENDER != 0
             float dissolveAlpha = 0.0;
-            OVERRIDE_DISSOLVE
+            if (fd.dissolveActive)
+            {
+                float priorAlpha = fd.col.a;
+                fd.col.a = 1.0f;
+                OVERRIDE_DISSOLVE
+                if (fd.dissolveInvert)
+                {
+                    fd.col.a = 1.0f - fd.col.a;
+                }
+                        
+                fd.col.a *= priorAlpha;
+            }
         #endif
 
         //------------------------------------------------------------------------------------------------------------------------------

--- a/Assets/lilToon/Shader/Includes/lil_pass_motionvectors.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_motionvectors.hlsl
@@ -53,7 +53,7 @@ struct v2f
         float4 uv23         : TEXCOORD2;
     #endif
     #if defined(LIL_V2F_POSITION_OS)
-        float3 positionOS   : TEXCOORD3;
+        float4 positionOSdissolve   : TEXCOORD3;
     #endif
     #if defined(LIL_V2F_POSITION_WS)
         float3 positionWS   : TEXCOORD4;

--- a/Assets/lilToon/Shader/Includes/lil_pass_shadowcaster.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_shadowcaster.hlsl
@@ -39,7 +39,7 @@ struct v2f
         float4 uv23         : TEXCOORD2;
     #endif
     #if defined(LIL_V2F_POSITION_OS)
-        float3 positionOS   : TEXCOORD3;
+        float4 positionOSdissolve   : TEXCOORD3;
     #endif
     #if defined(LIL_V2F_POSITION_WS)
         float3 positionWS   : TEXCOORD4;

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -464,6 +464,16 @@ Shader "lilToon"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonCutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonCutoutOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonFur"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonFurCutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonFurTwoPass"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonGem"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonOnePassTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonOverlay"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonRefraction"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonRefractionBlur"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellation"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationCutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -464,6 +464,16 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTwoPassTransparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -464,6 +464,16 @@ Shader "_lil/lilToonMulti"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonMultiFur"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonMultiGem"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonMultiOutline"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -464,6 +464,16 @@ Shader "Hidden/lilToonMultiRefraction"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_cutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_opaque"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_proponly.shader
+++ b/Assets/lilToon/Shader/ltspass_proponly.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_proponly"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_tess_cutout"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_tess_opaque"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_tess_transparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -464,6 +464,16 @@ Shader "Hidden/ltspass_transparent"
                         _IDMaskIndex7               ("_IDMaskIndex7", Int) = 0
                         _IDMaskIndex8               ("_IDMaskIndex8", Int) = 0
 
+        [ToggleUI]      _IDMaskControlsDissolve     ("_IDMaskControlsDissolve", Int) = 0
+        [ToggleUI]      _IDMaskPrior1               ("_IDMaskPrior1", Int) = 0
+        [ToggleUI]      _IDMaskPrior2               ("_IDMaskPrior2", Int) = 0
+        [ToggleUI]      _IDMaskPrior3               ("_IDMaskPrior3", Int) = 0
+        [ToggleUI]      _IDMaskPrior4               ("_IDMaskPrior4", Int) = 0
+        [ToggleUI]      _IDMaskPrior5               ("_IDMaskPrior5", Int) = 0
+        [ToggleUI]      _IDMaskPrior6               ("_IDMaskPrior6", Int) = 0
+        [ToggleUI]      _IDMaskPrior7               ("_IDMaskPrior7", Int) = 0
+        [ToggleUI]      _IDMaskPrior8               ("_IDMaskPrior8", Int) = 0
+
         //----------------------------------------------------------------------------------------------------------------------
         // Encryption
         [lilToggle]     _IgnoreEncryption           ("sIgnoreEncryption", Int) = 0


### PR DESCRIPTION
This adds a new _IDMaskControlsDissolve flag, as well as a second set of mask flags (_IDMaskPrior1...8).

With _IDMaskControlsDissolve true, dissolve will be enabled/disabled, and/or its state inverted, based on the state of the IDMask flags. In particular:

* Not masked in _IDMask array, not masked in _IDMaskPrior: Not dissolved
* Masked in both _IDMask and _IDMaskPrior: Hidden by vertex shader
* Masked in only _IDMask: Dissolved
* Masked in only _IDMaskPrior: Dissolved, but the effect of dissolve on the main texture alpha is inverted.

The intent of this is to allow for a wipe transition where multiple parts of multiple meshes are dissolved (to either appear or disappear) with their dissolve positions synced. This allows for this effect to be done in units smaller than a full mesh.