### PR TITLE
Fix Gem FORWARD_PRE LightMode never being set/overridden

### DIFF
--- a/Assets/lilToon/CustomShaderResources/BRP/DefaultGem.lilblock
+++ b/Assets/lilToon/CustomShaderResources/BRP/DefaultGem.lilblock
@@ -22,6 +22,7 @@
         Pass
         {
             Name "FORWARD_PRE"
+            Tags {"LightMode" = "*LIL_LIGHTMODE_FORWARD_0*"}
             Stencil
             {
                 Ref [_StencilRef]

--- a/Assets/lilToon/CustomShaderResources/BRP/DefaultMultiGem.lilblock
+++ b/Assets/lilToon/CustomShaderResources/BRP/DefaultMultiGem.lilblock
@@ -35,6 +35,7 @@
         Pass
         {
             Name "FORWARD_PRE"
+            Tags {"LightMode" = "*LIL_LIGHTMODE_FORWARD_0*"}
             Stencil
             {
                 Ref [_StencilRef]

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -743,6 +743,7 @@ Shader "Hidden/lilToonGem"
         Pass
         {
             Name "FORWARD_PRE"
+            Tags {"LightMode" = "ForwardBase"}
             Stencil
             {
                 Ref [_StencilRef]

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -652,6 +652,7 @@ Shader "Hidden/lilToonMultiGem"
         Pass
         {
             Name "FORWARD_PRE"
+            Tags {"LightMode" = "ForwardBase"}
             Stencil
             {
                 Ref [_StencilRef]


### PR DESCRIPTION
It looks like that this was simply forgotten, and would cause issues with specific setups (like using VRCFury to generate an SPS Shader using lilToon gem).

This also fixes the pass never being changed by the override in lilToon settings!