### PR TITLE
Allow choosing a specific frame when Zero FPS is supplied to a Spritesheet

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_functions.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_functions.hlsl
@@ -514,9 +514,17 @@ float2 lilCalcDecalUV(
 float2 lilCalcAtlasAnimation(float2 uv, float4 decalAnimation, float4 decalSubParam)
 {
     float2 outuv = lerp(float2(uv.x, 1.0-uv.y), 0.5, decalSubParam.z);
-    uint animTime = (uint)(LIL_TIME * decalAnimation.w) % (uint)decalAnimation.z;
-    uint offsetX = animTime % (uint)decalAnimation.x;
-    uint offsetY = animTime / (uint)decalAnimation.x;
+    uint animFrame;
+    if (decalAnimation.w == 0.0)
+    {
+        animFrame = (uint)decalAnimation.z;
+    }
+    else
+    {
+        animFrame = (uint)(LIL_TIME * decalAnimation.w) % (uint)decalAnimation.z;
+    }
+    uint offsetX = animFrame % (uint)decalAnimation.x;
+    uint offsetY = animFrame / (uint)decalAnimation.x;
     outuv = (outuv + float2(offsetX,offsetY)) * decalSubParam.xy / decalAnimation.xy;
     outuv.y = 1.0-outuv.y;
     return outuv;


### PR DESCRIPTION
I wanted to use decals and their Spritesheet feature to switch between many designs on my avatar's shirt, however I wasn't able to choose a single frame easily.

This change may affect existing setups that have a sprite sheet enabled but FPS set to 0, as a different sprite may be shown. But I felt that keeping the manual sprite selection zero-indexed was important, plus I wanted to keep it as simple as possible. I will happily edit this if needed!

https://github.com/lilxyzw/lilToon/assets/20761757/a3806e2f-a6e0-43c0-b696-a10928c4ae99

