### PR TITLE
Check for UV Discard in vert before lighting/post-proc effects

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
@@ -246,6 +246,21 @@ LIL_V2F_TYPE vert(appdata input)
     #endif
 
     //------------------------------------------------------------------------------------------------------------------------------
+    // UDIM Discard
+    #if defined(LIL_FEATURE_UDIMDISCARD) && !defined(LIL_LITE)
+    if(_UDIMDiscardMode == 0 && _UDIMDiscardCompile == 1 && LIL_CHECK_UDIMDISCARD(input)) // Discard Vertices instead of just pixels
+    {
+        #if defined(LIL_V2F_POSITION_CS)
+        LIL_V2F_OUT_BASE.positionCS = 0.0/0.0;
+        #endif
+        #if defined(LIL_ONEPASS_OUTLINE)
+        LIL_V2F_OUT.positionCSOL = 0.0/0.0;
+        #endif
+        return LIL_V2F_OUT;
+    }
+    #endif
+    
+    //------------------------------------------------------------------------------------------------------------------------------
     // Fog & Lighting
     lilFragData fd = lilInitFragData();
     LIL_GET_HDRPDATA(vertexInput,fd);
@@ -410,20 +425,6 @@ LIL_V2F_TYPE vert(appdata input)
         #if defined(LIL_ONEPASS_OUTLINE)
             LIL_V2F_OUT.positionCSOL = idMasked ? 0.0/0.0 : LIL_V2F_OUT.positionCSOL;
         #endif
-    #endif
-
-    //------------------------------------------------------------------------------------------------------------------------------
-    // UDIM Discard
-    #if defined(LIL_FEATURE_UDIMDISCARD) && !defined(LIL_LITE)
-        if(_UDIMDiscardMode == 0 && _UDIMDiscardCompile == 1 && LIL_CHECK_UDIMDISCARD(input)) // Discard Vertices instead of just pixels
-        {
-            #if defined(LIL_V2F_POSITION_CS)
-                LIL_V2F_OUT_BASE.positionCS = 0.0/0.0;
-            #endif
-            #if defined(LIL_ONEPASS_OUTLINE)
-                LIL_V2F_OUT.positionCSOL = 0.0/0.0;
-            #endif
-        }
     #endif
 
     #if defined(LIL_V2F_POSITION_OS)

--- a/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
@@ -124,6 +124,18 @@ v2g vert(appdata input)
     LIL_CUSTOM_VERT_COPY
 
     //------------------------------------------------------------------------------------------------------------------------------
+    // UDIM Discard
+    #if defined(LIL_FEATURE_UDIMDISCARD) && !defined(LIL_LITE)
+        if(_UDIMDiscardMode == 0 && _UDIMDiscardCompile == 1 && LIL_CHECK_UDIMDISCARD(input)) // Discard Vertices instead of just pixels
+        {
+            #if defined(LIL_V2F_POSITION_CS)
+            output.positionWS = 0.0/0.0;
+            #endif
+            return output;
+        }
+    #endif
+    
+    //------------------------------------------------------------------------------------------------------------------------------
     // Fog & Lighting
     lilFragData fd = lilInitFragData();
     LIL_GET_HDRPDATA(vertexInput,fd);
@@ -223,17 +235,6 @@ v2g vert(appdata input)
         #if defined(LIL_V2G_POSITION_WS)
             output.positionWS = idMasked ? 0.0/0.0 : output.positionWS;
         #endif
-    #endif
-
-    //------------------------------------------------------------------------------------------------------------------------------
-    // UDIM Discard
-    #if defined(LIL_FEATURE_UDIMDISCARD) && !defined(LIL_LITE)
-        if(_UDIMDiscardMode == 0 && _UDIMDiscardCompile == 1 && LIL_CHECK_UDIMDISCARD(input)) // Discard Vertices instead of just pixels
-        {
-            #if defined(LIL_V2F_POSITION_CS)
-            output.positionWS = 0.0/0.0;
-            #endif
-        }
     #endif
 
     return output;


### PR DESCRIPTION
Closes #179 

I saw the issue and decided to give a quick shot at fixing it. Seems like the "Fog and Lighting" section was causing it. Since we're discarding the vertex anyway, it didn't seem prudent to keep that. 

(Frankly, we could move UV Discard and even ID Mask further up, potentially near Invisible, to avoid performing unneeded calculations that will be discarded anyway. Would like to hear your thoughts on it!)

The change did not seem to be needed on the Fur shader, but I moved it to preserve parity. Let me know if I should revert that.

EDIT: Oops! I didn't check `dev` before the switch! My bad! 🙇 