### PR TITLE
docs: reflect Unity series range onto short-description

### DIFF
--- a/en-us/README.md
+++ b/en-us/README.md
@@ -31,7 +31,7 @@ lilToon is a shader developed for avatar-based services and has the following fe
 
 <div class="flex2">
 <h3>Stable</h3>
-<p>It is compatible with all types of Unity lighting, so the brightness is close to that of Standard Shader. It also supports a wide range of Unity versions for use in a variety of environments over a long period of time, reducing the need for shader migration. (Unity2017 - 2021, BRP/LWRP/URP/HDRP)</p>
+<p>It is compatible with all types of Unity lighting, so the brightness is close to that of Standard Shader. It also supports a wide range of Unity versions for use in a variety of environments over a long period of time, reducing the need for shader migration. (Unity2018 - 2023, BRP/LWRP/URP/HDRP)</p>
 </div>
 </div>
 

--- a/ja-jp/README.md
+++ b/ja-jp/README.md
@@ -29,7 +29,7 @@
 
 <div class="flex2">
 <h3>安定</h3>
-<p>Unityの全ライティングに対応済みでStandard Shaderに近い明るさに。さらに長期間、様々な環境で利用できるように幅広いUnityバージョンに対応しており、シェーダー移行の手間を減らします。（Unity2017 - 2021、BRP/LWRP/URP/HDRP）</p>
+<p>Unityの全ライティングに対応済みでStandard Shaderに近い明るさに。さらに長期間、様々な環境で利用できるように幅広いUnityバージョンに対応しており、シェーダー移行の手間を減らします。（Unity2018 - 2023、BRP/LWRP/URP/HDRP）</p>
 </div>
 </div>
 


### PR DESCRIPTION
トップページの説明セクションにおいて、Unityのバージョンの範囲をその下の対応状況セクションに合わせました。