### PR TITLE
VRCワールドアップロードできない問題を修正

### DIFF
--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -774,7 +774,10 @@ public class lilToonSetting : ScriptableObject
                 }
             }
         }
-        UnityEditor.SceneManagement.EditorSceneManager.OpenScene(startScenePath);
+        if (UnityEngine.SceneManagement.SceneManager.sceneCountInBuildSettings > 0)
+        {
+            UnityEditor.SceneManagement.EditorSceneManager.OpenScene(startScenePath);
+        }
     }
     
     internal static void ApplyShaderSettingOptimized(List<Shader> shaders = null)


### PR DESCRIPTION
https://github.com/lilxyzw/lilToon/issues/214 の修正です。  
`Scenes In Build`が空の場合は最適化後にシーンを開きなおさないよう修正しました。