### PR TITLE
only define audiolink types if cginc not included

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -899,7 +899,7 @@ SAMPLER(sampler_AudioLinkMask);
 SAMPLER(sampler_OutlineTex);
 
 // AudioLink
-#if defined(LIL_FEATURE_AUDIOLINK)
+#if defined(LIL_FEATURE_AUDIOLINK) && !defined(AUDIOLINK_CGINC_INCLUDED)
 TEXTURE2D_FLOAT(_AudioTexture);
 float4 _AudioTexture_TexelSize;
 #endif


### PR DESCRIPTION
this allows creating custom shaders that include `AudioLink.cginc` from the `com.llealloo.audiolink` package.

there is no issue for optimized shaders, but in the editor this would error out with the types already defined.