### PR TITLE
fix: disable clipping canceller in mirror

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
@@ -286,13 +286,13 @@ LIL_V2F_TYPE vert(appdata input)
     #if defined(LIL_V2F_POSITION_CS) && defined(LIL_FEATURE_CLIPPING_CANCELLER) && !defined(LIL_LITE) && !defined(LIL_PASS_SHADOWCASTER_INCLUDED) && !defined(LIL_PASS_META_INCLUDED)
         #if defined(UNITY_REVERSED_Z)
             // DirectX
-            if(LIL_V2F_OUT_BASE.positionCS.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT_BASE.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(LIL_V2F_OUT_BASE.positionCS.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT_BASE.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 LIL_V2F_OUT_BASE.positionCS.z = LIL_V2F_OUT_BASE.positionCS.z * 0.0001 + LIL_V2F_OUT_BASE.positionCS.w * 0.999;
             }
         #else
             // OpenGL
-            if(LIL_V2F_OUT_BASE.positionCS.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT_BASE.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(LIL_V2F_OUT_BASE.positionCS.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT_BASE.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 LIL_V2F_OUT_BASE.positionCS.z = LIL_V2F_OUT_BASE.positionCS.z * 0.0001 - LIL_V2F_OUT_BASE.positionCS.w * 0.999;
             }
@@ -315,13 +315,13 @@ LIL_V2F_TYPE vert(appdata input)
         #if defined(LIL_FEATURE_CLIPPING_CANCELLER) && !defined(LIL_LITE) && !defined(LIL_PASS_SHADOWCASTER_INCLUDED) && !defined(LIL_PASS_META_INCLUDED)
             #if defined(UNITY_REVERSED_Z)
                 // DirectX
-                if(LIL_V2F_OUT.positionCSOL.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT.positionCSOL.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(LIL_V2F_OUT.positionCSOL.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT.positionCSOL.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     LIL_V2F_OUT.positionCSOL.z = LIL_V2F_OUT.positionCSOL.z * 0.0001 + LIL_V2F_OUT.positionCSOL.w * 0.999;
                 }
             #else
                 // OpenGL
-                if(LIL_V2F_OUT.positionCSOL.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT.positionCSOL.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(LIL_V2F_OUT.positionCSOL.w < _ProjectionParams.y * 1.01 && LIL_V2F_OUT.positionCSOL.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     LIL_V2F_OUT.positionCSOL.z = LIL_V2F_OUT.positionCSOL.z * 0.0001 - LIL_V2F_OUT.positionCSOL.w * 0.999;
                 }

--- a/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert_fur.hlsl
@@ -300,13 +300,13 @@ void AppendFur(inout TriangleStream<v2f> outStream, inout v2f output, v2g input[
         // Clipping Canceller
         #if defined(UNITY_REVERSED_Z)
             // DirectX
-            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 output.positionCS.z = output.positionCS.z * 0.0001 + output.positionCS.w * 0.999;
             }
         #else
             // OpenGL
-            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 output.positionCS.z = output.positionCS.z * 0.0001 - output.positionCS.w * 0.999;
             }
@@ -344,13 +344,13 @@ void AppendFur(inout TriangleStream<v2f> outStream, inout v2f output, v2g input[
         // Clipping Canceller
         #if defined(UNITY_REVERSED_Z)
             // DirectX
-            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 output.positionCS.z = output.positionCS.z * 0.0001 + output.positionCS.w * 0.999;
             }
         #else
             // OpenGL
-            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+            if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
             {
                 output.positionCS.z = output.positionCS.z * 0.0001 - output.positionCS.w * 0.999;
             }

--- a/Assets/lilToon/Shader/Includes/lil_common_vert_fur_thirdparty.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert_fur_thirdparty.hlsl
@@ -106,13 +106,13 @@ for(uint fl = 0; fl < _FurLayerNum; fl++)
             // Clipping Canceller
             #if defined(UNITY_REVERSED_Z)
                 // DirectX
-                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     output.positionCS.z = output.positionCS.z * 0.0001 + output.positionCS.w * 0.999;
                 }
             #else
                 // OpenGL
-                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     output.positionCS.z = output.positionCS.z * 0.0001 - output.positionCS.w * 0.999;
                 }
@@ -149,13 +149,13 @@ for(uint fl = 0; fl < _FurLayerNum; fl++)
             // Clipping Canceller
             #if defined(UNITY_REVERSED_Z)
                 // DirectX
-                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     output.positionCS.z = output.positionCS.z * 0.0001 + output.positionCS.w * 0.999;
                 }
             #else
                 // OpenGL
-                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING)
+                if(output.positionCS.w < _ProjectionParams.y * 1.01 && output.positionCS.w > 0 && _ProjectionParams.y < LIL_NEARCLIP_THRESHOLD LIL_MULTI_SHOULD_CLIPPING && !LIL_IS_MIRROR)
                 {
                     output.positionCS.z = output.positionCS.z * 0.0001 - output.positionCS.w * 0.999;
                 }


### PR DESCRIPTION
Resolves #250 です。
すでにミラー判定用のマクロが用意されていたので `_VRChatMirrorMode` ではなくそちらを使用しています。

issue のコメントで

> ミラーでの表示の問題の対策としては near clip が 0.1 より大きかった場合には描画するという形になってるので、

と触れられていますが、`LIL_NEARCLIP_THRESHOLD` による判定を無くしてもよかったりしますか？
別の問題 (精度等？) がなければ消しますがいかがでしょうか。