### PR TITLE
fix: backward compatibility fixes

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
@@ -657,7 +657,7 @@ namespace lilToon
         private lilMaterialProperty[] allProperty;
         private lilMaterialProperty[] AllProperties()
         {
-            return allProperty ??= new[]
+            return allProperty != null ? allProperty : allProperty = new[]
             {
                 invisible,
                 cutoff,
@@ -1337,7 +1337,7 @@ namespace lilToon
                     var lilPorp = allProps[i];
                     foreach(var block in lilPorp.blocks)
                     {
-                        if(block2Propertes.ContainsKey(block) is false) { block2Propertes[block] = new(); }
+                        if(!block2Propertes.ContainsKey(block)) { block2Propertes[block] = new List<lilMaterialProperty>(); }
                         block2Propertes[block].Add(lilPorp);
                     }
                 }

--- a/Assets/lilToon/Editor/lilMaterialProperty.cs
+++ b/Assets/lilToon/Editor/lilMaterialProperty.cs
@@ -102,7 +102,7 @@ namespace lilToon
         public lilMaterialProperty(string name, params PropertyBlock[] inBrocks)
         {
             p = null;
-            blocks = inBrocks.ToHashSet();
+            blocks = new HashSet<PropertyBlock>(inBrocks);
             isTexture = false;
             propertyName = name;
         }
@@ -110,7 +110,7 @@ namespace lilToon
         public lilMaterialProperty(string name, bool isTex, params PropertyBlock[] inBrocks)
         {
             p = null;
-            blocks = inBrocks.ToHashSet();
+            blocks = new HashSet<PropertyBlock>(inBrocks);
             isTexture = isTex;
             propertyName = name;
         }


### PR DESCRIPTION
古いUnity (Unity 2019.4.31f) にて， 1.8.5 から 1.9.0 へアップデートすると，下記3つのコンパイルエラーが発生しました．

## 発生したコンパイルエラー

### null合体代入演算子

[null合体代入演算子 `??=`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/null-coalescing-operator "https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-80")は [C# 8.0 からの言語仕様](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-80 "The history of C# | Microsoft Learn") であるため， Unity 2020.2 以降でなければコンパイルできません．

そのため， Unity 2019.4.31f では下記のコンパイルエラーが発生します．

- [当該箇所](https://github.com/lilxyzw/lilToon/blob/1.9.0/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs#L660-L1297 "lilToon/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs at 1.9.0 · lilxyzw/lilToon")

```
Assets\lilToon\Editor\lilInspector\lilMaterialProperties.cs(660,34): error CS1525: Invalid expression term '='
```

### ターゲット型のnew式

[ターゲット型のnew式](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/target-typed-new "Target-typed new expressions - C# feature specifications | Microsoft Learn") は [C# 9.0 からの言語仕様](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-9 "C# 9.0 からの言語仕様")であるため， Unity 2021.2 以降でなければコンパイルできません．

そのため， Unity 2019.4.31f では下記のコンパイルエラーが発生します．

- [当該箇所](https://github.com/lilxyzw/lilToon/blob/1.9.0/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs#L1340 "lilToon/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs at 1.9.0 · lilxyzw/lilToon")

```
Assets\lilToon\Editor\lilInspector\lilMaterialProperties.cs(1340,104): error CS8124: Tuple must contain at least two elements.
Assets\lilToon\Editor\lilInspector\lilMaterialProperties.cs(1340,105): error CS1526: A new expression requires (), [], or {} after type
```

### Enumerable.ToHashSet

[`Enumerable.ToHashSet`](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.tohashset "Enumerable.ToHashSet Method (System.Linq) | Microsoft Learn")は .NET Framework 4.7.2 からの導入であるため， Unity 2021.2 以降でなければコンパイルできないと思われます．

- [当該箇所1](https://github.com/lilxyzw/lilToon/blob/1.9.0/Assets/lilToon/Editor/lilMaterialProperty.cs#L105 "lilToon/Assets/lilToon/Editor/lilMaterialProperty.cs at 1.9.0 · lilxyzw/lilToon")
- [当該箇所2](https://github.com/lilxyzw/lilToon/blob/1.9.0/Assets/lilToon/Editor/lilMaterialProperty.cs#L113 "lilToon/Assets/lilToon/Editor/lilMaterialProperty.cs at 1.9.0 · lilxyzw/lilToon")

```
Assets\lilToon\Editor\lilMaterialProperty.cs(105,31): error CS1061: 'PropertyBlock[]' does not contain a definition for 'ToHashSet' and no accessible extension method 'ToHashSet' accepting a first argument of type 'PropertyBlock[]' could be found (are you missing a using directive or an assembly reference?)
Assets\lilToon\Editor\lilMaterialProperty.cs(113,31): error CS1061: 'PropertyBlock[]' does not contain a definition for 'ToHashSet' and no accessible extension method 'ToHashSet' accepting a first argument of type 'PropertyBlock[]' could be found (are you missing a using directive or an assembly reference?)
```

---

下記2点により，Unityの後方互換性をとる修正をしてみました．

- [README.md](https://github.com/lilxyzw/lilToon/blob/1.9.0/Assets/lilToon/README.md "Assets/lilToon/README.md")に記載されているサポートUnityバージョンが Unity 2018.1 - Unity 2023.2 であること
- コンパイルエラーが3点であったこと

Unity 2021.2 以前を切り捨てるのであれば，このプルリクエストは却下していただいて問題ありません．