### PR TITLE
fix: backward compatibility fixes

### DIFF
--- a/Assets/lilToon/Editor/lilToon2Ramp.cs
+++ b/Assets/lilToon/Editor/lilToon2Ramp.cs
@@ -29,7 +29,11 @@ namespace lilToon
         {
             var tex = Convert(origin, width);
 
-            if(string.IsNullOrEmpty(path)) path = AssetDatabase.GetAssetPath(origin)[..^4] + "_ramp.png";
+            if(string.IsNullOrEmpty(path))
+            {
+                path = AssetDatabase.GetAssetPath(origin);
+                path = path.Substring(0, path.Length - 4) + "_ramp.png";
+            }
             File.WriteAllBytes(path, tex.EncodeToPNG());
             Object.DestroyImmediate(tex);
 

--- a/Assets/lilToon/Editor/lilToonEditorUtils.cs
+++ b/Assets/lilToon/Editor/lilToonEditorUtils.cs
@@ -171,8 +171,8 @@ namespace lilToon
         {
             foreach (var o in Selection.objects)
             {
-                if(o is not Material m || !lilMaterialUtils.CheckShaderIslilToon(m)) continue;
-                    lilToon2Ramp.ConvertAndSave(m);
+                if(!(o is Material m) || !lilMaterialUtils.CheckShaderIslilToon(m)) continue;
+                lilToon2Ramp.ConvertAndSave(m);
             }
         }
 


### PR DESCRIPTION
#261 と同様にUnity 2019/Unity 2020向けの C# の互換性を考慮した変更となります．

## 発生したコンパイルエラー

### IndexとRange

`AssetDatabase.GetAssetPath(origin)[..^4]` のような[IndexとRangeを用いた記法](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/ranges-indexes "Explore ranges of data using indices and ranges - C# | Microsoft Learn")は [C# 8.0](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-80 "The history of C# | Microsoft Learn") からの機能であるため，Unity 2020.2 以降でなければコンパイルできません．

#### Unity 2019.4.31fで発生したコンパイルエラー

- [当該箇所](https://github.com/lilxyzw/lilToon/blob/1.10.3/Assets/lilToon/Editor/lilToon2Ramp.cs#L32 "lilToon/Assets/lilToon/Editor/lilToon2Ramp.cs at 1.10.3 · lilxyzw/lilToon")

```
Assets\lilToon\Editor\lilToon2Ramp.cs(32,86): error CS1001: Identifier expected
Assets\lilToon\Editor\lilToon2Ramp.cs(32,88): error CS1525: Invalid expression term '^'
```

### パターンマッチ: `is not`

[パターンマッチ: `is not`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns#logical-patterns "Patterns - Pattern matching using the is and switch expressions. - C# reference | Microsoft Learn") は [C# 9](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-9 "The history of C# | Microsoft Learn") からの機能であるため，Unity 2021.2 以降でなければコンパイルできません．

- [当該箇所](https://github.com/lilxyzw/lilToon/blob/1.10.3/Assets/lilToon/Editor/lilToonEditorUtils.cs#L174 "lilToon/Assets/lilToon/Editor/lilToonEditorUtils.cs at 1.10.3 · lilxyzw/lilToon")

#### Unity 2019.4.31fで発生したコンパイルエラー

```
Assets\lilToon\Editor\lilToonEditorUtils.cs(174,38): error CS1026: ) expected
Assets\lilToon\Editor\lilToonEditorUtils.cs(174,84): error CS1002: ; expected
Assets\lilToon\Editor\lilToonEditorUtils.cs(174,84): error CS1513: } expected
```