### PR TITLE
Toon Standard への Fallback 時の Shading モードの指定

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -600,3 +600,7 @@
         [HideInInspector]                               _BaseMap            ("Texture", 2D) = "white" {}
         [HideInInspector]                               _BaseColorMap       ("Texture", 2D) = "white" {}
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 0
+
+        //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}

--- a/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
@@ -597,6 +597,10 @@
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 0
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
@@ -263,12 +263,12 @@ namespace lilToon
                     EditorGUI.showMixedValue = false;
                     if(EditorGUI.EndChangeCheck())
                     {
+                        m_MaterialEditor.RegisterPropertyChangeUndo("VRCFallback");
                         foreach(var obj in m_MaterialEditor.targets.Where(obj => obj is Material))
                         {
                             ((Material)obj).SetOverrideTag("VRCFallback", tag);
                             EditorUtility.SetDirty(obj);
                         }
-                        AssetDatabase.SaveAssets();
                     }
                     EditorGUILayout.EndVertical();
                 }

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
@@ -654,6 +654,8 @@ namespace lilToon
         private readonly lilMaterialProperty matcapMul              = new lilMaterialProperty("_MatCapMul", PropertyBlock.MatCaps, PropertyBlock.MatCap1st);
         private readonly lilMaterialProperty fakeShadowVector       = new lilMaterialProperty("_FakeShadowVector", PropertyBlock.Base);
 
+        private readonly lilMaterialProperty ramp = new lilMaterialProperty("_Ramp", true);
+
         private lilMaterialProperty[] allProperty;
         private lilMaterialProperty[] AllProperties()
         {
@@ -1294,6 +1296,8 @@ namespace lilToon
                 triMask,
                 matcapMul,
                 fakeShadowVector,
+
+                ramp,
             };
         }
 

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -605,6 +605,10 @@ Shader "lilToon"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonCutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonCutoutOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonFur"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonFurCutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonFurTwoPass"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonGem"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 0
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonOnePassTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonOverlay"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonRefraction"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonRefractionBlur"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellation"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationCutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -605,6 +605,10 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTwoPassTransparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -605,6 +605,10 @@ Shader "_lil/lilToonMulti"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonMultiFur"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonMultiGem"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 0
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonMultiOutline"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -605,6 +605,10 @@ Shader "Hidden/lilToonMultiRefraction"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_cutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_opaque"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_proponly.shader
+++ b/Assets/lilToon/Shader/ltspass_proponly.shader
@@ -600,6 +600,10 @@ Shader "Hidden/ltspass_proponly"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_tess_cutout"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_tess_opaque"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("sCullModes", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_tess_transparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -605,6 +605,10 @@ Shader "Hidden/ltspass_transparent"
         [HideInInspector]                               _lilToonVersion     ("Version", Int) = 45
 
         //----------------------------------------------------------------------------------------------------------------------
+        // VRChat
+        _Ramp ("Shadow Ramp", 2D) = "white" {}
+
+        //----------------------------------------------------------------------------------------------------------------------
         // Advanced
         [lilEnum]                                       _Cull               ("Cull Mode|Off|Front|Back", Int) = 2
         [Enum(UnityEngine.Rendering.BlendMode)]         _SrcBlend           ("sSrcBlendRGB", Int) = 1


### PR DESCRIPTION
Toon Standard に Fallback した時の Shading モード (_Ramp テクスチャ) を選択できるようにしました。

VRCFallback タグで指定させてくれた方が良いとは思っていますが、今のところ反応がなさそうなので _Ramp を実装しました。
https://feedback.vrchat.com/open-beta/p/381-beta4-shading-modes-in-vrcfallback-for-toon-standard-shader

Unlit (これまで通り)
![image](https://github.com/user-attachments/assets/d46521b4-1628-4468-b92e-3df0ed9664ca)

Toon Standard (Realistic)
![image](https://github.com/user-attachments/assets/82f92e6c-7f59-4020-92f1-176f3b3b04d1)

Toon Standard (Custom)
![image](https://github.com/user-attachments/assets/1a33ce17-5e19-4b9b-9b92-a49f31218bb7)

ついでに VRCFallback に Undo が効いていなかったので修正しました。