### PR TITLE
fix: normal custom shader changes are not applied for outline rendering

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_vert.hlsl
@@ -95,19 +95,17 @@ LIL_V2F_TYPE vert(appdata input)
     float2 uvs[4] = {uvMain,input.uv1,input.uv2,input.uv3};
 
     //------------------------------------------------------------------------------------------------------------------------------
-    // Object space direction
-    #if defined(LIL_APP_NORMAL) && defined(LIL_APP_TANGENT)
-        float3 bitangentOS = normalize(cross(input.normalOS, input.tangentOS.xyz)) * (input.tangentOS.w * length(input.normalOS));
-        float3x3 tbnOS = float3x3(input.tangentOS.xyz, bitangentOS, input.normalOS);
-    #else
-        float3 bitangentOS = 0.0;
-        float3x3 tbnOS = 0.0;
-    #endif
-
-    //------------------------------------------------------------------------------------------------------------------------------
     // Vertex Modification
     #include "lil_vert_encryption.hlsl"
     lilCustomVertexOS(input, uvMain, input.positionOS);
+    // Object space direction after applying custom shader in Object Space
+    #if defined(LIL_APP_NORMAL) && defined(LIL_APP_TANGENT)
+    float3 bitangentOS = normalize(cross(input.normalOS, input.tangentOS.xyz)) * (input.tangentOS.w * length(input.normalOS));
+    float3x3 tbnOS = float3x3(input.tangentOS.xyz, bitangentOS, input.normalOS);
+    #else
+    float3 bitangentOS = 0.0;
+    float3x3 tbnOS = 0.0;
+    #endif
     #include "lil_vert_audiolink.hlsl"
     #if !defined(LIL_ONEPASS_OUTLINE)
         #include "lil_vert_outline.hlsl"


### PR DESCRIPTION
カスタムシェーダで normal の向きを変更した際に、アウトラインの生成に使われる normal がカスタムシェーダが変更したものではなくオリジナルのモデルの法線が使用される問題を修正します。

最適化がかかって`LIL_FEATURE_OutlineVectorTex`が定義されていない場合には意図した通りカスタムシェーダが変更したものが適応されています。