### PR TITLE
docs: add index for guide to migrate v1 to v2

### DIFF
--- a/docs/.vitepress/config/ja_JP.ts
+++ b/docs/.vitepress/config/ja_JP.ts
@@ -74,6 +74,7 @@ export const ja_JP = defineConfig({
           { text: 'シェーダー設定', link: langName + '/other/settings' },
           { text: 'メニューの追加項目', link: langName + '/other/menuitem' },
           { text: 'テクスチャのインポート設定について', link: langName + '/other/textures' },
+          { text: '【重要】バージョン1.xから2.xへの移行について', link: langName + '/migrate1to2' },
           { text: 'Q&A', link: langName + '/other/qa' },
           { text: '変更履歴', link: langName + '/other/changelog' },
         ]


### PR DESCRIPTION
バージョン1.xから2.xへの移行に関するページが目次に掲載されておらず、ほぼ直接リンクからのアクセスのみ可能な状況になっていたため、目次を追加しました。
(`【重要】`については、ページ側と表記を揃えました。有無はどちらでも良いと考えます。)

一般ユーザー向けの記述もあったため、開発者向けではなくその他の章に追加しました。
otherフォルダ以下に移動していないのは、私がvitepressでのリダイレクトの設定方法が分からなかったためです。