### PR TITLE
fix: light direction for VRCLV is not used #319

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_fur.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_fur.hlsl
@@ -88,19 +88,13 @@ float4 frag(v2f input) : SV_Target
     LIL_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
     lilFragData fd = lilInitFragData();
 
-    BEFORE_UNPACK_V2F
-    OVERRIDE_UNPACK_V2F
-    LIL_GET_HDRPDATA(input,fd);
-    #if defined(LIL_V2F_SHADOW) || defined(LIL_PASS_FORWARDADD)
-        LIL_LIGHT_ATTENUATION(fd.attenuation, input);
-    #endif
-
     // For VRCLV
     #if defined(LIL_BRP) && defined(LIL_PASS_FORWARD) && defined(VRC_LIGHT_VOLUMES_INCLUDED) && (defined(LIL_INPUT_OPTIMIZED) || defined(LIL_MULTI))
         if(_UdonLightVolumeEnabled)
         {
             lilVertexPositionInputs vertexInput = lilGetVertexPositionInputsFromWS(input.positionWS);
             lilVertexNormalInputs vertexNormalInput = lilGetVertexNormalInputsFromWS(input.normalWS);
+            LIL_UNPACK_TEXCOORD1(input,fd);
             #define input fd
             LIL_CALC_MAINLIGHT(vertexInput, lightdataInput);
             #undef input
@@ -114,6 +108,13 @@ float4 frag(v2f input) : SV_Target
                 input.indLightColor  = lightdataInput.indLightColor;
             #endif
         }
+    #endif
+
+    BEFORE_UNPACK_V2F
+    OVERRIDE_UNPACK_V2F
+    LIL_GET_HDRPDATA(input,fd);
+    #if defined(LIL_V2F_SHADOW) || defined(LIL_PASS_FORWARDADD)
+        LIL_LIGHT_ATTENUATION(fd.attenuation, input);
     #endif
 
     LIL_GET_LIGHTING_DATA(input,fd);

--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
@@ -115,20 +115,13 @@ float4 frag(v2f input LIL_VFACE(facing)) : SV_Target
     LIL_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
     lilFragData fd = lilInitFragData();
 
-    BEFORE_UNPACK_V2F
-    OVERRIDE_UNPACK_V2F
-    LIL_COPY_VFACE(fd.facing);
-    LIL_GET_HDRPDATA(input,fd);
-    #if defined(LIL_V2F_SHADOW) || defined(LIL_PASS_FORWARDADD)
-        LIL_LIGHT_ATTENUATION(fd.attenuation, input);
-    #endif
-
     // For VRCLV
     #if defined(LIL_BRP) && defined(LIL_PASS_FORWARD) && defined(VRC_LIGHT_VOLUMES_INCLUDED) && (defined(LIL_INPUT_OPTIMIZED) || defined(LIL_MULTI))
         if(_UdonLightVolumeEnabled)
         {
             lilVertexPositionInputs vertexInput = lilGetVertexPositionInputsFromWS(input.positionWS);
             lilVertexNormalInputs vertexNormalInput = lilGetVertexNormalInputsFromWS(input.normalWS);
+            LIL_UNPACK_TEXCOORD1(input,fd);
             #define input fd
             LIL_CALC_MAINLIGHT(vertexInput, lightdataInput);
             #undef input
@@ -142,6 +135,14 @@ float4 frag(v2f input LIL_VFACE(facing)) : SV_Target
                 input.indLightColor  = lightdataInput.indLightColor;
             #endif
         }
+    #endif
+
+    BEFORE_UNPACK_V2F
+    OVERRIDE_UNPACK_V2F
+    LIL_COPY_VFACE(fd.facing);
+    LIL_GET_HDRPDATA(input,fd);
+    #if defined(LIL_V2F_SHADOW) || defined(LIL_PASS_FORWARDADD)
+        LIL_LIGHT_ATTENUATION(fd.attenuation, input);
     #endif
 
     LIL_GET_LIGHTING_DATA(input,fd);


### PR DESCRIPTION
#319 の修正案です．
[フラグメントシェーダーにおけるVRCLVのライト方向の取得＆頂点シェーダーからの受け渡し処理が， `OVERRIDE_UNPACK_V2F` より後にある](https://github.com/lilxyzw/lilToon/blob/2.1.7/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl#L118-L145 "Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl") ために， `fd.L`, `fd.origL` にライト方向が入らない点の修正となります．
フラグメントシェーダーの入力構造体のVRCLVに関する項目の上書き処理を `BEFORE_UNPACK_V2F` の前に持ってくる対応を行っております．
`#define input fd` は [LTCGI適用のための `fd.uv1` 参照](https://github.com/lilxyzw/lilToon/blob/2.1.7/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl#L2084 "Assets/lilToon/Shader/Includes/lil_common_macro.hlsl#L2084") のためと判断し，直前に `LIL_UNPACK_TEXCOORD1(input,fd);` を入れています．

---

* fix: #319