### PR TITLE
fix: don't draw _Ramp texture property on the inspector of the shader…

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
@@ -176,7 +176,7 @@ namespace lilToon
                         int fallbackCullType = tag.Contains("DoubleSided") ? 1 : 0;
 
                         int fallbackShadingType = -1;
-                        if(ramp.textureValue)
+                        if(ramp.p != null && ramp.textureValue)
                         {
                             var path = AssetDatabase.GetAssetPath(ramp.textureValue);
                             var guid = AssetDatabase.AssetPathToGUID(path);
@@ -221,7 +221,7 @@ namespace lilToon
                             default: break;
                         }
 
-                        if(tag.Contains("toonstandard"))
+                        if(ramp.p != null && tag.Contains("toonstandard"))
                         {
                             EditorGUI.BeginChangeCheck();
                             fallbackShadingType = lilEditorGUI.Popup("Shading", fallbackShadingType, sFallbackShadingTypes);
@@ -244,7 +244,10 @@ namespace lilToon
                         }
                         else
                         {
-                            ramp.textureValue = null;
+                            if(ramp.p != null)
+                            {
+                                ramp.textureValue = null;
+                            }
                             EditorGUILayout.LabelField("Result", '"' + tag + '"');
                         }
 
@@ -253,7 +256,10 @@ namespace lilToon
                     else
                     {
                         tag = "";
-                        ramp.textureValue = null;
+                        if(ramp.p != null)
+                        {
+                            ramp.textureValue = null;
+                        }
                     }
                     EditorGUI.showMixedValue = false;
                     if(EditorGUI.EndChangeCheck())


### PR DESCRIPTION
#323 の対応案です．
`_Ramp` テクスチャプロパティを持たないFakeShadowやLite系のシェーダーにおいては，VRChat欄のCustom Safety Fallbackにて "toonstandard" または "toonstandardoutline" を選択していたとしても， `_Ramp` テクスチャを指定するためのShading欄を表示しない方向で対応してみました．