### PR TITLE
fix: errors in the inspector after the initial import #334

### DIFF
--- a/Assets/lilToon/Editor/Localization/Localization.cs
+++ b/Assets/lilToon/Editor/Localization/Localization.cs
@@ -42,7 +42,7 @@ namespace lilToon
 
         internal static string L(string key)
         {
-            if(!instance.localizationAsset) Load();
+            if (!instance.localizationAsset || !instance.localizationAssetFallback) Load();
             var localized = instance.localizationAsset.GetLocalizedString(key);
             return localized != key ? localized : instance.localizationAssetFallback.GetLocalizedString(key);
         }
@@ -54,7 +54,7 @@ namespace lilToon
 
         private static GUIContent G(string key, Texture image, string tooltip)
         {
-            if (!instance.localizationAsset) Load();
+            if (!instance.localizationAsset || !instance.localizationAssetFallback) Load();
             if (guicontents.TryGetValue(key, out var content)) return content;
             return guicontents[key] = new GUIContent(L(key), image, L(tooltip));
         }

--- a/Assets/lilToon/Editor/Localization/Localization.cs
+++ b/Assets/lilToon/Editor/Localization/Localization.cs
@@ -28,7 +28,7 @@ namespace lilToon
 
         internal static string[] GetLanguages()
         {
-            return languages ??= Directory.GetFiles(localizationFolder).Where(f => f.EndsWith(".po")).Select(f => Path.GetFileNameWithoutExtension(f)).Where(f => !f.StartsWith("._")).ToArray();
+            return languages ??= Directory.GetFiles(localizationFolder, "*.po").Where(f => !f.StartsWith("._")).Select(f => Path.GetFileNameWithoutExtension(f)).ToArray();
         }
 
         internal static string[] GetLanguageNames()

--- a/Assets/lilToon/Editor/lilStartup.cs
+++ b/Assets/lilToon/Editor/lilStartup.cs
@@ -18,10 +18,6 @@ namespace lilToon
         {
             //------------------------------------------------------------------------------------------------------------------------------
             // Variables
-            #pragma warning disable CS0612
-            lilLanguageManager.InitializeLanguage();
-            #pragma warning restore CS0612
-
             AssetDatabase.importPackageStarted -= PackageVersionChecker;
             AssetDatabase.importPackageStarted += PackageVersionChecker;
             EditorApplication.playModeStateChanged -= PlayModeStateChanged;


### PR DESCRIPTION
This is a fix for editor error #334.

The [first commit](https://github.com/lilxyzw/lilToon/pull/337/commits/5f39f65ac8383ed57c6b5a6f5d48e6684edf7174 "5f39f65ac8383ed57c6b5a6f5d48e6684edf7174") is a simple addition of a null check.
This prevents the error from continuing to occur, eliminating the need for users to reimport lilToon or restart Unity.

However, the first commit alone does not prevent the error message from appearing once during the initial import of lilToon.
The [second commit](https://github.com/lilxyzw/lilToon/pull/337/commits/3d3062f27914203a7835c80cebb8673d174ea6b4 "3d3062f27914203a7835c80cebb8673d174ea6b4") removes the loading of language resources during startup.
Since loading language in OnGUI(), I believe there is no need to load language resources during startup.

- [`lilInspector.OnGUI()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilInspector/lilInspector.cs#L41 "Assets/lilToon/Editor/lilInspector/lilInspector")
- [`lilInspector.DrawAllGUI()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilInspector/lilInspector.cs#L89 "Assets/lilToon/Editor/lilInspector/lilInspector.cs")
- [`lilLanguageManager.SelectLang()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilLanguageManager.cs#L108 "Assets/lilToon/Editor/lilLanguageManager.cs")
- [`lilLanguageManager.InitializeLanguage()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilLanguageManager.cs#L97 "Assets/lilToon/Editor/lilLanguageManager.cs")
- [`lilLanguageManager.UpdateLanguage()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilLanguageManager.cs#L103 "Assets/lilToon/Editor/lilLanguageManager.cs")
- [`lilLanguageManager.InitializeLabels()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilLanguageManager.cs#L144 "Assets/lilToon/Editor/lilLanguageManager.cs")
- [`lilLanguageManager.GetLoc()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/lilLanguageManager.cs#L80 "Assets/lilToon/Editor/lilLanguageManager.cs")
- [`L10n.L()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/Localization/Localization.cs#L45 "Assets/lilToon/Editor/Localization/Localization.cs")
- [`L10n.Load()`](https://github.com/lilxyzw/lilToon/blob/2.1.10/Assets/lilToon/Editor/Localization/Localization.cs#L23-L25 "Assets/lilToon/Editor/Localization/Localization.cs")

If there is a second commit, the first commit is not necessary.
However, I think this will be a good measure in case language resources are added during startup in the future.

The [third commit](https://github.com/lilxyzw/lilToon/pull/337/commits/5aa64c08318f400a26dde7b318e31cdbbf45d247 "5aa64c08318f400a26dde7b318e31cdbbf45d247") is just refactoring, optimizing the generation of language file path arrays.