### PR TITLE
fix: outline highlights no longer function #336

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_normal.hlsl
@@ -176,6 +176,12 @@ float4 frag(v2f input LIL_VFACE(facing)) : SV_Target
         OVERRIDE_CALC_DDX_DDY
 
         //------------------------------------------------------------------------------------------------------------------------------
+        // Normal
+        #if defined(LIL_V2F_NORMAL_WS)
+            fd.N = normalize(input.normalWS);
+        #endif
+
+        //------------------------------------------------------------------------------------------------------------------------------
         // Main Color
         BEFORE_OUTLINE_COLOR
         OVERRIDE_OUTLINE_COLOR


### PR DESCRIPTION
This is amendment #336.
I fixed it so that the value is set to `fd.N` at the point before `OVERRIDE_OUTLINE_COLOR`.

---

* fix: #336