### PR TITLE
Calculate emission fluorescence from light color luminance

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common.hlsl
@@ -66,7 +66,7 @@ struct lilFragData
     float3 indLightColor;
     float3 addLightColor;
     float attenuation;
-    float3 invLighting;
+    float fluorescence;
 
     // UV
     float2 uv0;
@@ -141,12 +141,12 @@ lilFragData lilInitFragData()
     fd.col = 1.0;
     fd.albedo = 1.0;
     fd.emissionColor = 0.0;
+    fd.fluorescence = 1.0;
 
     fd.lightColor = 1.0;
     fd.indLightColor = 0.0;
     fd.addLightColor = 0.0;
     fd.attenuation = 1.0;
-    fd.invLighting = 0.0;
 
     fd.uv0 = 0.0;
     fd.uv1 = 0.0;

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -1856,7 +1856,7 @@
             #if defined(LIL_FEATURE_AUDIOLINK)
                 if(_AudioLink2Emission) emissionColor.a *= fd.audioLinkValue;
             #endif
-            emissionColor.rgb = lerp(emissionColor.rgb, emissionColor.rgb * fd.invLighting, _EmissionFluorescence);
+            emissionColor.a *= lerp(1.0, fd.fluorescence, _EmissionFluorescence);
             emissionColor.rgb = lerp(emissionColor.rgb, emissionColor.rgb * fd.albedo, _EmissionMainStrength);
             float emissionBlend = _EmissionBlend * lilCalcBlink(_EmissionBlink) * emissionColor.a;
             #if LIL_RENDER == 2 && !defined(LIL_REFRACTION)
@@ -1940,7 +1940,7 @@
             #if defined(LIL_FEATURE_AUDIOLINK)
                 if(_AudioLink2Emission2nd) emission2ndColor.a *= fd.audioLinkValue;
             #endif
-            emission2ndColor.rgb = lerp(emission2ndColor.rgb, emission2ndColor.rgb * fd.invLighting, _Emission2ndFluorescence);
+            emission2ndColor.a *= lerp(1.0, fd.fluorescence, _Emission2ndFluorescence);
             emission2ndColor.rgb = lerp(emission2ndColor.rgb, emission2ndColor.rgb * fd.albedo, _Emission2ndMainStrength);
             float emission2ndBlend = _Emission2ndBlend * lilCalcBlink(_Emission2ndBlink) * emission2ndColor.a;
             #if LIL_RENDER == 2 && !defined(LIL_REFRACTION)

--- a/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
@@ -116,6 +116,10 @@
     float lilLuminance(float3 rgb) { return dot(rgb, float3(0.0396819152, 0.458021790, 0.00609653955)); }
 #endif
 
+float lilFluorescence(float3 rgb) {
+    return pow(1.0 - saturate(lilLuminance(rgb)), 3.0);
+}
+
 // Initialize struct
 #if defined(UNITY_INITIALIZE_OUTPUT)
     #define LIL_INITIALIZE_STRUCT(type,name) UNITY_INITIALIZE_OUTPUT(type,name)
@@ -2303,12 +2307,12 @@ struct lilLightData
         LIL_GET_MAINLIGHT(input, fd.lightColor, fd.L, fd.attenuation); \
         fd.origL = fd.L; \
         LIL_GET_ADDITIONALLIGHT(input, fd.addLightColor); \
-        fd.invLighting = saturate((1.0 - fd.lightColor) * sqrt(fd.lightColor))
+        fd.fluorescence = lilFluorescence(fd.lightColor)
 #else
     #define LIL_GET_LIGHTING_DATA(input,fd) \
         LIL_GET_MAINLIGHT(input, fd.lightColor, fd.L, fd.attenuation); \
         LIL_GET_ADDITIONALLIGHT(input, fd.addLightColor); \
-        fd.invLighting = saturate((1.0 - fd.lightColor) * sqrt(fd.lightColor))
+        fd.fluorescence = lilFluorescence(fd.lightColor)
 #endif
 
 #define LIL_GET_POSITION_WS_DATA(input,fd) \

--- a/Assets/lilToon/Shader/Includes/lil_pass_forward_fur.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_pass_forward_fur.hlsl
@@ -215,7 +215,7 @@ float4 frag(v2f input) : SV_Target
         OVERRIDE_RIMSHADE
     #endif
 
-    fd.col.rgb += input.furLayer * pow(saturate(1-abs(dot(normalize(fd.N), fd.V))), _FurRimFresnelPower) * lerp(1,lilGray(fd.invLighting), _FurRimAntiLight) * _FurRimColor.rgb * fd.lightColor;
+    fd.col.rgb += input.furLayer * pow(saturate(1-abs(dot(normalize(fd.N), fd.V))), _FurRimFresnelPower) * lerp(1, fd.fluorescence, _FurRimAntiLight) * _FurRimColor.rgb * fd.lightColor;
 
     //------------------------------------------------------------------------------------------------------------------------------
     // Distance Fade


### PR DESCRIPTION
Current (emission) fluorescence math takes light's RGB and naively flips its channels, which leads to artifacts like this:

<details>

<summary>Screenshot</summary>

<img width="1541" height="859" src="https://github.com/user-attachments/assets/932ec49e-3234-4170-a98a-df2d047baf27" />

</details>

With changes from this PR it looks like:

<details>

<summary>Screenshot</summary>

<img width="1541" height="859" src="https://github.com/user-attachments/assets/07e9e59f-d820-4feb-8496-724b752be270" />

</details>

Material is Opaque lilToon with black main color, white emission and fluorescence set to 1 (this is important part). But it looks worse on real avatars, most noticeable in worlds like [Complex 7](https://vrchat.com/home/world/wrld_ff414a30-31e3-44bb-9c8e-3d721e895b0b) with a lot of colored light sources.


