### PR TITLE
fix: AudioLinkMask does not work in the vertex shader #343

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_vert_audiolink.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_vert_audiolink.hlsl
@@ -18,7 +18,7 @@
 
         // Mask (R:Delay G:Band B:Strength)
         float4 audioLinkMask = 1.0;
-        #if defined(Use_AudioLinkMask)
+        #if defined(LIL_FEATURE_AudioLinkMask)
             if(_AudioLinkVertexUVMode == 3)
             {
                 float2 uvMask = uvMain;


### PR DESCRIPTION
#343 の修正です．

---

* close #343