### PR TITLE
fix: Distance Clipping Canceller in "Shader Setting" does not affect multi shader material #346

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilInspector.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilInspector.cs
@@ -102,7 +102,7 @@ namespace lilToon
             {
                 case EditorMode.Advanced:   DrawAdvancedGUI(material); break;
                 case EditorMode.Preset:     DrawPresetGUI(); break;
-                case EditorMode.Settings:   DrawSettingsGUI(); break;
+                case EditorMode.Settings:   DrawSettingsGUI(material); break;
             }
 
             if(EditorGUI.EndChangeCheck())

--- a/Assets/lilToon/Editor/lilInspector/lilSettingAndPresetGUI.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilSettingAndPresetGUI.cs
@@ -29,7 +29,7 @@ namespace lilToon
             else        DrawPreset();
         }
 
-        private void DrawSettingsGUI()
+        private void DrawSettingsGUI(Material material)
         {
             var applyButton = new GUIStyle(GUI.skin.button);
             applyButton.normal.textColor = Color.red;
@@ -63,7 +63,12 @@ namespace lilToon
             {
                 EditorGUILayout.BeginVertical(customBox);
                 GUI.enabled = !isLocked;
+                EditorGUI.BeginChangeCheck();
                 ToggleGUI(GetLoc("sSettingClippingCanceller"), ref shaderSetting.LIL_FEATURE_CLIPPING_CANCELLER);
+                if(EditorGUI.EndChangeCheck())
+                {
+                    material.SetFloat("_UseClippingCanceller", shaderSetting.LIL_FEATURE_CLIPPING_CANCELLER ? 1.0f : 0.0f);
+                }
                 GUI.enabled = true;
                 EditorGUILayout.EndVertical();
             }


### PR DESCRIPTION
#346 の修正案です．

「シェーダー設定」の「シェーダー設定（全マテリアル共通）」欄の「距離クリッピングキャンセラー」チェックボックスがMulti系のシェーダーマテリアルに作用しないため，チェックボックス変更時に `_UseClippingCanceller` の値に反映するようにしてみました．

ただ，Multi系のシェーダーであれば「詳細設定」の「基本設定欄」に個別設定用の「距離クリッピングキャンセラー」チェックボックスが表示されるので，仕様であるのではないかとも思っています．
このプルリクエストの修正だと，Multi系シェーダーマテリアルで個別設定した距離クリッピングキャンセラーが全体の設定変更じに上書きされてしまうことも考えられますので...．
仕様であればこのプルリクエストは棄却してください．

---

* fix: #346