### PR TITLE
refactor: improved shader type detection based on name

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
@@ -289,20 +289,22 @@ namespace lilToon
         #region
         private void CheckShaderType(Material material)
         {
-            isLite          = lilShaderUtils.IsLiteShaderName(material.shader.name);
-            isCutout        = lilShaderUtils.IsCutoutShaderName(material.shader.name);
-            isTransparent   = lilShaderUtils.IsTransparentShaderName(material.shader.name) || lilShaderUtils.IsOverlayShaderName(material.shader.name);
-            isOutl          = !isMultiVariants && lilShaderUtils.IsOutlineShaderName(material.shader.name);
-            isRefr          = !isMultiVariants && lilShaderUtils.IsRefractionShaderName(material.shader.name);
-            isBlur          = !isMultiVariants && lilShaderUtils.IsBlurShaderName(material.shader.name);
-            isFur           = !isMultiVariants && lilShaderUtils.IsFurShaderName(material.shader.name);
-            isTess          = !isMultiVariants && lilShaderUtils.IsTessellationShaderName(material.shader.name);
-            isGem           = !isMultiVariants && lilShaderUtils.IsGemShaderName(material.shader.name);
-            isFakeShadow    = !isMultiVariants && lilShaderUtils.IsFakeShadowShaderName(material.shader.name);
-            isOnePass       = lilShaderUtils.IsOnePassShaderName(material.shader.name);
-            isTwoPass       = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
-            isMulti         = lilShaderUtils.IsMultiShaderName(material.shader.name);
-            isCustomShader  = lilShaderUtils.IsOptionalShaderName(material.shader.name);
+            var shaderName = material.shader.name;
+
+            isLite          = lilShaderUtils.IsLiteShaderName(shaderName);
+            isCutout        = lilShaderUtils.IsCutoutShaderName(shaderName);
+            isTransparent   = lilShaderUtils.IsTransparentShaderName(shaderName) || lilShaderUtils.IsOverlayShaderName(shaderName);
+            isOutl          = !isMultiVariants && lilShaderUtils.IsOutlineShaderName(shaderName);
+            isRefr          = !isMultiVariants && lilShaderUtils.IsRefractionShaderName(shaderName);
+            isBlur          = !isMultiVariants && lilShaderUtils.IsBlurShaderName(shaderName);
+            isFur           = !isMultiVariants && lilShaderUtils.IsFurShaderName(shaderName);
+            isTess          = !isMultiVariants && lilShaderUtils.IsTessellationShaderName(shaderName);
+            isGem           = !isMultiVariants && lilShaderUtils.IsGemShaderName(shaderName);
+            isFakeShadow    = !isMultiVariants && lilShaderUtils.IsFakeShadowShaderName(shaderName);
+            isOnePass       = lilShaderUtils.IsOnePassShaderName(shaderName);
+            isTwoPass       = lilShaderUtils.IsTwoPassShaderName(shaderName);
+            isMulti         = lilShaderUtils.IsMultiShaderName(shaderName);
+            isCustomShader  = lilShaderUtils.IsOptionalShaderName(shaderName);
             isShowRenderMode = !isCustomShader;
             isStWr          = stencilPass.floatValue == (float)StencilOp.Replace;
 

--- a/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
@@ -86,7 +86,7 @@ namespace lilToon
 
         private static void DrawShaderTypeWarn(Material material)
         {
-            if(!isMultiVariants && material.shader.name.Contains("Overlay") && lilEditorGUI.AutoFixHelpBox(GetLoc("sHelpSelectOverlay")))
+            if(!isMultiVariants && lilShaderUtils.IsOverlayShaderName(material.shader.name) && lilEditorGUI.AutoFixHelpBox(GetLoc("sHelpSelectOverlay")))
             {
                 material.shader = lts;
             }
@@ -289,20 +289,20 @@ namespace lilToon
         #region
         private void CheckShaderType(Material material)
         {
-            isLite          = material.shader.name.Contains("Lite");
-            isCutout        = material.shader.name.Contains("Cutout");
-            isTransparent   = material.shader.name.Contains("Transparent") || material.shader.name.Contains("Overlay");
-            isOutl          = !isMultiVariants && material.shader.name.Contains("Outline");
-            isRefr          = !isMultiVariants && material.shader.name.Contains("Refraction");
-            isBlur          = !isMultiVariants && material.shader.name.Contains("Blur");
-            isFur           = !isMultiVariants && material.shader.name.Contains("Fur");
-            isTess          = !isMultiVariants && material.shader.name.Contains("Tessellation");
-            isGem           = !isMultiVariants && material.shader.name.Contains("Gem");
-            isFakeShadow    = !isMultiVariants && material.shader.name.Contains("FakeShadow");
-            isOnePass       = material.shader.name.Contains("OnePass");
-            isTwoPass       = material.shader.name.Contains("TwoPass");
-            isMulti         = material.shader.name.Contains("Multi");
-            isCustomShader  = material.shader.name.Contains("Optional");
+            isLite          = lilShaderUtils.IsLiteShaderName(material.shader.name);
+            isCutout        = lilShaderUtils.IsCutoutShaderName(material.shader.name);
+            isTransparent   = lilShaderUtils.IsTransparentShaderName(material.shader.name) || lilShaderUtils.IsOverlayShaderName(material.shader.name);
+            isOutl          = !isMultiVariants && lilShaderUtils.IsOutlineShaderName(material.shader.name);
+            isRefr          = !isMultiVariants && lilShaderUtils.IsRefractionShaderName(material.shader.name);
+            isBlur          = !isMultiVariants && lilShaderUtils.IsBlurShaderName(material.shader.name);
+            isFur           = !isMultiVariants && lilShaderUtils.IsFurShaderName(material.shader.name);
+            isTess          = !isMultiVariants && lilShaderUtils.IsTessellationShaderName(material.shader.name);
+            isGem           = !isMultiVariants && lilShaderUtils.IsGemShaderName(material.shader.name);
+            isFakeShadow    = !isMultiVariants && lilShaderUtils.IsFakeShadowShaderName(material.shader.name);
+            isOnePass       = lilShaderUtils.IsOnePassShaderName(material.shader.name);
+            isTwoPass       = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
+            isMulti         = lilShaderUtils.IsMultiShaderName(material.shader.name);
+            isCustomShader  = lilShaderUtils.IsOptionalShaderName(material.shader.name);
             isShowRenderMode = !isCustomShader;
             isStWr          = stencilPass.floatValue == (float)StencilOp.Replace;
 

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialConvertUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialConvertUtility.cs
@@ -225,8 +225,8 @@ namespace lilToon
             if(renderingMode == RenderingMode.FurCutout)        renderingMode = RenderingMode.Cutout;
             if(renderingMode == RenderingMode.FurTwoPass)       renderingMode = RenderingMode.Transparent;
 
-            bool isonepass      = material.shader.name.Contains("OnePass");
-            bool istwopass      = material.shader.name.Contains("TwoPass");
+            bool isonepass      = lilShaderUtils.IsOnePassShaderName(material.shader.name);
+            bool istwopass      = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
 
             var           transparentMode = TransparentMode.Normal;
             if(isonepass) transparentMode = TransparentMode.OnePass;

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialConvertUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialConvertUtility.cs
@@ -225,8 +225,9 @@ namespace lilToon
             if(renderingMode == RenderingMode.FurCutout)        renderingMode = RenderingMode.Cutout;
             if(renderingMode == RenderingMode.FurTwoPass)       renderingMode = RenderingMode.Transparent;
 
-            bool isonepass      = lilShaderUtils.IsOnePassShaderName(material.shader.name);
-            bool istwopass      = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
+            var shaderName = material.shader.name;
+            bool isonepass      = lilShaderUtils.IsOnePassShaderName(shaderName);
+            bool istwopass      = lilShaderUtils.IsTwoPassShaderName(shaderName);
 
             var           transparentMode = TransparentMode.Normal;
             if(isonepass) transparentMode = TransparentMode.OnePass;

--- a/Assets/lilToon/Editor/lilInspector/lilPropertyGroupDrawerAdvancedSetting.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilPropertyGroupDrawerAdvancedSetting.cs
@@ -18,7 +18,7 @@ namespace lilToon
         private void DrawOutlineSettings(Material material)
         {
             if(!ShouldDrawBlock(PropertyBlock.Outline)) return;
-            if(isMultiVariants || isRefr || isFur || isGem || isFakeShadow || material.shader.name.Contains("Overlay")) return;
+            if(isMultiVariants || isRefr || isFur || isGem || isFakeShadow || lilShaderUtils.IsOverlayShaderName(material.shader.name)) return;
             edSet.isShowOutline = lilEditorGUI.Foldout(GetLoc("sOutlineSetting"), edSet.isShowOutline);
             DrawMenuButton(GetLoc("sAnchorOutline"), PropertyBlock.Outline);
             if(edSet.isShowOutline)

--- a/Assets/lilToon/Editor/lilMaterialUtils.cs
+++ b/Assets/lilToon/Editor/lilMaterialUtils.cs
@@ -388,10 +388,11 @@ namespace lilToon
             bool useEmissionBlendMask = IsFeatureOnTexture(material, "_EmissionBlendMask");
             bool useEmission2ndBlendMask = IsFeatureOnTexture(material, "_Emission2ndBlendMask");
 
-            bool isOutl = lilShaderUtils.IsOutlineShaderName(material.shader.name);
-            bool isRefr = lilShaderUtils.IsRefractionShaderName(material.shader.name);
-            bool isFur = lilShaderUtils.IsFurShaderName(material.shader.name);
-            bool isGem = lilShaderUtils.IsGemShaderName(material.shader.name);
+            var shaderName = material.shader.name;
+            bool isOutl = lilShaderUtils.IsOutlineShaderName(shaderName);
+            bool isRefr = lilShaderUtils.IsRefractionShaderName(shaderName);
+            bool isFur = lilShaderUtils.IsFurShaderName(shaderName);
+            bool isGem = lilShaderUtils.IsGemShaderName(shaderName);
 
             SetShaderKeywords(material, "UNITY_UI_ALPHACLIP",                   tpmode == 1);
             SetShaderKeywords(material, "UNITY_UI_CLIP_RECT",                   tpmode == 2 || tpmode == 4);
@@ -540,8 +541,9 @@ namespace lilToon
 
         public static void RemoveUnusedTexture(Material material, params string[] animatedProps)
         {
-            if(!material.shader.name.Contains("lilToon")) return;
-            RemoveUnusedTexture(material, lilShaderUtils.IsLiteShaderName(material.shader.name), animatedProps);
+            var shaderName = material.shader.name;
+            if(!shaderName.Contains("lilToon")) return;
+            RemoveUnusedTexture(material, lilShaderUtils.IsLiteShaderName(shaderName), animatedProps);
         }
 
         public static void RemoveUnusedTexture(Material material, bool islite, params string[] animatedProps)
@@ -641,13 +643,14 @@ namespace lilToon
                     material.SetTexture("_MatCap2ndBlendMask", null);
                     material.SetTexture("_MatCap2ndBumpMap", null);
                 }
-                if(!lilShaderUtils.IsOutlineShaderName(material.shader.name))
+                var shaderName = material.shader.name;
+                if(!lilShaderUtils.IsOutlineShaderName(shaderName))
                 {
                     material.SetTexture("_OutlineTex", null);
                     material.SetTexture("_OutlineWidthMask", null);
                     material.SetTexture("_OutlineVectorTex", null);
                 }
-                if(!lilShaderUtils.IsFurShaderName(material.shader.name))
+                if(!lilShaderUtils.IsFurShaderName(shaderName))
                 {
                     material.SetTexture("_FurVectorTex", null);
                     material.SetTexture("_FurLengthMask", null);

--- a/Assets/lilToon/Editor/lilMaterialUtils.cs
+++ b/Assets/lilToon/Editor/lilMaterialUtils.cs
@@ -388,10 +388,10 @@ namespace lilToon
             bool useEmissionBlendMask = IsFeatureOnTexture(material, "_EmissionBlendMask");
             bool useEmission2ndBlendMask = IsFeatureOnTexture(material, "_Emission2ndBlendMask");
 
-            bool isOutl = material.shader.name.Contains("Outline");
-            bool isRefr = material.shader.name.Contains("Refraction");
-            bool isFur = material.shader.name.Contains("Fur");
-            bool isGem = material.shader.name.Contains("Gem");
+            bool isOutl = lilShaderUtils.IsOutlineShaderName(material.shader.name);
+            bool isRefr = lilShaderUtils.IsRefractionShaderName(material.shader.name);
+            bool isFur = lilShaderUtils.IsFurShaderName(material.shader.name);
+            bool isGem = lilShaderUtils.IsGemShaderName(material.shader.name);
 
             SetShaderKeywords(material, "UNITY_UI_ALPHACLIP",                   tpmode == 1);
             SetShaderKeywords(material, "UNITY_UI_CLIP_RECT",                   tpmode == 2 || tpmode == 4);
@@ -474,7 +474,7 @@ namespace lilToon
 
         public static void SetupMultiMaterial(Material[] materials, AnimationClip[] clips)
         {
-            var ms = materials.Where(m => m.shader.name.Contains("Multi")).ToArray();
+            var ms = materials.Where(m => lilShaderUtils.IsMultiShaderName(m.shader.name)).ToArray();
             foreach(var binding in clips.SelectMany(c => AnimationUtility.GetCurveBindings(c)).ToArray())
             {
                 string propname = binding.propertyName;
@@ -541,7 +541,7 @@ namespace lilToon
         public static void RemoveUnusedTexture(Material material, params string[] animatedProps)
         {
             if(!material.shader.name.Contains("lilToon")) return;
-            RemoveUnusedTexture(material, material.shader.name.Contains("Lite"), animatedProps);
+            RemoveUnusedTexture(material, lilShaderUtils.IsLiteShaderName(material.shader.name), animatedProps);
         }
 
         public static void RemoveUnusedTexture(Material material, bool islite, params string[] animatedProps)
@@ -641,13 +641,13 @@ namespace lilToon
                     material.SetTexture("_MatCap2ndBlendMask", null);
                     material.SetTexture("_MatCap2ndBumpMap", null);
                 }
-                if(!material.shader.name.Contains("Outline"))
+                if(!lilShaderUtils.IsOutlineShaderName(material.shader.name))
                 {
                     material.SetTexture("_OutlineTex", null);
                     material.SetTexture("_OutlineWidthMask", null);
                     material.SetTexture("_OutlineVectorTex", null);
                 }
-                if(!material.shader.name.Contains("Fur"))
+                if(!lilShaderUtils.IsFurShaderName(material.shader.name))
                 {
                     material.SetTexture("_FurVectorTex", null);
                     material.SetTexture("_FurLengthMask", null);

--- a/Assets/lilToon/Editor/lilShaderUtils.cs
+++ b/Assets/lilToon/Editor/lilShaderUtils.cs
@@ -1,0 +1,206 @@
+#if UNITY_EDITOR
+
+namespace lilToon
+{
+    public static class lilShaderUtils
+    {
+        public static bool IsLiteShaderName(string shaderName)
+        {
+            var separatorIndex = shaderName.LastIndexOf('/');
+            if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+            {
+                return false;
+            }
+
+            if (shaderName.IndexOf("Lite", separatorIndex + 1) != -1)
+            {
+                return true;
+            }
+
+            // For following custom shader names.
+            // - Hidden/*LIL_SHADER_NAME*/Lite/Cutout
+            // - Hidden/*LIL_SHADER_NAME*/Lite/Transparent
+            // - Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparent
+            // - Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparent
+            // - Hidden/*LIL_SHADER_NAME*/Lite/OpaqueOutline
+            // - Hidden/*LIL_SHADER_NAME*/Lite/CutoutOutline
+            // - Hidden/*LIL_SHADER_NAME*/Lite/TransparentOutline
+            // - Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparentOutline
+            // - Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparentOutline
+            var partIndex = shaderName.LastIndexOf("/Lite/");
+            if (partIndex != -1 && partIndex + 5 == separatorIndex)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsCutoutShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Cutout");
+        }
+
+        public static bool IsTransparentShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Transparent");
+        }
+
+        public static bool IsOverlayShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Overlay");
+        }
+
+        public static bool IsOutlineShaderName(string shaderName)
+        {
+            var separatorIndex = shaderName.LastIndexOf('/');
+            if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+            {
+                return false;
+            }
+
+            if (shaderName.IndexOf("Outline", separatorIndex + 1) != -1)
+            {
+                return true;
+            }
+
+            // For following custom shader names.
+            // - *LIL_SHADER_NAME*/[Optional] OutlineOnly/Opaque
+            // - *LIL_SHADER_NAME*/[Optional] OutlineOnly/Cutout
+            // - *LIL_SHADER_NAME*/[Optional] OutlineOnly/Transparent
+            var partIndex = shaderName.LastIndexOf("/[Optional] OutlineOnly/");
+            if (partIndex != -1 && partIndex + 23 == separatorIndex)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsRefractionShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Refraction");
+        }
+
+        public static bool IsRefractionBlurShaderName(string shaderName)
+        {
+            return shaderName.EndsWith("RefractionBlur");
+        }
+
+        public static bool IsBlurShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Blur");
+        }
+
+        public static bool IsFurShaderName(string shaderName)
+        {
+            var separatorIndex = shaderName.LastIndexOf('/');
+            if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+            {
+                return false;
+            }
+
+            if (shaderName.IndexOf("Fur", separatorIndex + 1) != -1)
+            {
+                return true;
+            }
+
+            // For following custom shader names.
+            // - *LIL_SHADER_NAME*/[Optional] FurOnly/Transparent
+            // - *LIL_SHADER_NAME*/[Optional] FurOnly/Cutout
+            // - *LIL_SHADER_NAME*/[Optional] FurOnly/TwoPass
+            var partIndex = shaderName.LastIndexOf("/[Optional] FurOnly/");
+            if (partIndex != -1 && partIndex + 19 == separatorIndex)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsFurCutoutShaderName(string shaderName)
+        {
+            return shaderName.EndsWith("FurCutout");
+        }
+
+        public static bool IsFurTwoPassShaderName(string shaderName)
+        {
+            return shaderName.EndsWith("FurTwoPass");
+        }
+
+        public static bool IsTessellationShaderName(string shaderName)
+        {
+            var separatorIndex = shaderName.LastIndexOf('/');
+            if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+            {
+                return false;
+            }
+
+            if (shaderName.IndexOf("Tessellation", separatorIndex + 1) > 0)
+            {
+                return true;
+            }
+
+            // For following custom shader names.
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/Opaque
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/Cutout
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/Transparent
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparent
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparent
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/OpaqueOutline
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/CutoutOutline
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/TransparentOutline
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparentOutline
+            // - Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparentOutline
+            var partIndex = shaderName.LastIndexOf("/Tessellation/");
+            if (partIndex != -1 && partIndex + 13 == separatorIndex)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsGemShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Gem");
+        }
+
+        public static bool IsFakeShadowShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "FakeShadow");
+        }
+
+        public static bool IsOnePassShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "OnePass");
+        }
+
+        public static bool IsTwoPassShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "TwoPass");
+        }
+
+        public static bool IsMultiShaderName(string shaderName)
+        {
+            return ContainsAfterLastSeparator(shaderName, "Multi");
+        }
+
+        public static bool IsOptionalShaderName(string shaderName)
+        {
+            return shaderName.Contains("/[Optional] ");
+        }
+
+        private static bool ContainsAfterLastSeparator(string shaderName, string subName)
+        {
+            var separatorIndex = shaderName.LastIndexOf('/');
+            if (separatorIndex == -1 || separatorIndex + 1 == shaderName.Length)
+            {
+                return false;
+            }
+
+            return shaderName.IndexOf(subName, separatorIndex + 1) != -1;
+        }
+    }
+}
+#endif

--- a/Assets/lilToon/Editor/lilShaderUtils.cs.meta
+++ b/Assets/lilToon/Editor/lilShaderUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d52c549e503168f4e87f76590f546749
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/lilToon/Editor/lilToonAssetPostprocessor.cs
+++ b/Assets/lilToon/Editor/lilToonAssetPostprocessor.cs
@@ -16,7 +16,7 @@ namespace lilToon
                 if(!lilMaterialUtils.CheckShaderIslilToon(material)) continue;
 
                 lilStartup.MigrateMaterial(material);
-                if(material.shader.name.Contains("Multi"))
+                if(lilShaderUtils.IsMultiShaderName(material.shader.name))
                 {
                     lilMaterialUtils.SetupMultiMaterial(material);
                 }

--- a/Assets/lilToon/Editor/lilToonEditorUtils.cs
+++ b/Assets/lilToon/Editor/lilToonEditorUtils.cs
@@ -362,7 +362,7 @@ namespace lilToon
             else if(materialLowerName.Contains("hair"))                                         lilToonPreset.ApplyPreset(material, presetHair, false);
             else                                                                                lilToonPreset.ApplyPreset(material, presetCloth, false);
 
-            bool isOutl = material.shader.name.Contains("Outline");
+            bool isOutl = lilShaderUtils.IsOutlineShaderName(material.shader.name);
 
             if(!material.HasProperty("_ShadowStrengthMask") || material.GetTexture("_ShadowStrengthMask") == null)
             {

--- a/Assets/lilToon/Editor/lilToonPreset.cs
+++ b/Assets/lilToon/Editor/lilToonPreset.cs
@@ -67,17 +67,17 @@ public class lilToonPreset : ScriptableObject
             material.SetFloat(f.name, f.value);
         }
         if(preset.shader != null) material.shader = preset.shader;
-        bool isoutl         = preset.outline == -1 ? material.shader.name.Contains("Outline") : (preset.outline == 1);
-        bool istess         = preset.tessellation == -1 ? material.shader.name.Contains("Tessellation") : (preset.tessellation == 1);
+        bool isoutl         = preset.outline == -1 ? lilShaderUtils.IsOutlineShaderName(material.shader.name) : (preset.outline == 1);
+        bool istess         = preset.tessellation == -1 ? lilShaderUtils.IsTessellationShaderName(material.shader.name) : (preset.tessellation == 1);
 
-        bool islite         = material.shader.name.Contains("Lite");
-        bool iscutout       = material.shader.name.Contains("Cutout");
-        bool istransparent  = material.shader.name.Contains("Transparent");
-        bool isrefr         = material.shader.name.Contains("Refraction");
-        bool isblur         = material.shader.name.Contains("Blur");
-        bool isfur          = material.shader.name.Contains("Fur");
-        bool isonepass      = material.shader.name.Contains("OnePass");
-        bool istwopass      = material.shader.name.Contains("TwoPass");
+        bool islite         = lilShaderUtils.IsLiteShaderName(material.shader.name);
+        bool iscutout       = lilShaderUtils.IsCutoutShaderName(material.shader.name);
+        bool istransparent  = lilShaderUtils.IsTransparentShaderName(material.shader.name);
+        bool isrefr         = lilShaderUtils.IsRefractionShaderName(material.shader.name);
+        bool isblur         = lilShaderUtils.IsBlurShaderName(material.shader.name);
+        bool isfur          = lilShaderUtils.IsFurShaderName(material.shader.name);
+        bool isonepass      = lilShaderUtils.IsOnePassShaderName(material.shader.name);
+        bool istwopass      = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
 
         var renderingMode = RenderingMode.Opaque;
 
@@ -212,17 +212,17 @@ public class lilToonPreset : ScriptableObject
             Array.Resize(ref preset.textures, 0);
             if(material.shader != null && !string.IsNullOrEmpty(material.shader.name))
             {
-                isOutl        = material.shader.name.Contains("Outline");
-                isTess        = material.shader.name.Contains("Tessellation");
+                isOutl        = lilShaderUtils.IsOutlineShaderName(material.shader.name);
+                isTess        = lilShaderUtils.IsTessellationShaderName(material.shader.name);
                 renderingMode = RenderingMode.Opaque;
-                if(material.shader.name.Contains("Cutout"))         renderingMode = RenderingMode.Cutout;
-                if(material.shader.name.Contains("Transparent"))    renderingMode = RenderingMode.Transparent;
-                if(material.shader.name.Contains("Refraction"))     renderingMode = RenderingMode.Refraction;
-                if(material.shader.name.Contains("RefractionBlur")) renderingMode = RenderingMode.RefractionBlur;
-                if(material.shader.name.Contains("Fur"))            renderingMode = RenderingMode.Fur;
-                if(material.shader.name.Contains("FurCutout"))      renderingMode = RenderingMode.FurCutout;
-                if(material.shader.name.Contains("FurTwoPass"))     renderingMode = RenderingMode.FurTwoPass;
-                if(material.shader.name.Contains("Gem"))            renderingMode = RenderingMode.Gem;
+                if(lilShaderUtils.IsCutoutShaderName(material.shader.name))         renderingMode = RenderingMode.Cutout;
+                if(lilShaderUtils.IsTransparentShaderName(material.shader.name))    renderingMode = RenderingMode.Transparent;
+                if(lilShaderUtils.IsRefractionShaderName(material.shader.name))     renderingMode = RenderingMode.Refraction;
+                if(lilShaderUtils.IsRefractionBlurShaderName(material.shader.name)) renderingMode = RenderingMode.RefractionBlur;
+                if(lilShaderUtils.IsFurShaderName(material.shader.name))            renderingMode = RenderingMode.Fur;
+                if(lilShaderUtils.IsFurCutoutShaderName(material.shader.name))      renderingMode = RenderingMode.FurCutout;
+                if(lilShaderUtils.IsFurTwoPassShaderName(material.shader.name))     renderingMode = RenderingMode.FurTwoPass;
+                if(lilShaderUtils.IsGemShaderName(material.shader.name))            renderingMode = RenderingMode.Gem;
             }
             else
             {

--- a/Assets/lilToon/Editor/lilToonPreset.cs
+++ b/Assets/lilToon/Editor/lilToonPreset.cs
@@ -67,17 +67,18 @@ public class lilToonPreset : ScriptableObject
             material.SetFloat(f.name, f.value);
         }
         if(preset.shader != null) material.shader = preset.shader;
-        bool isoutl         = preset.outline == -1 ? lilShaderUtils.IsOutlineShaderName(material.shader.name) : (preset.outline == 1);
-        bool istess         = preset.tessellation == -1 ? lilShaderUtils.IsTessellationShaderName(material.shader.name) : (preset.tessellation == 1);
+        var shaderName = material.shader.name;
+        bool isoutl         = preset.outline == -1 ? lilShaderUtils.IsOutlineShaderName(shaderName) : (preset.outline == 1);
+        bool istess         = preset.tessellation == -1 ? lilShaderUtils.IsTessellationShaderName(shaderName) : (preset.tessellation == 1);
 
-        bool islite         = lilShaderUtils.IsLiteShaderName(material.shader.name);
-        bool iscutout       = lilShaderUtils.IsCutoutShaderName(material.shader.name);
-        bool istransparent  = lilShaderUtils.IsTransparentShaderName(material.shader.name);
-        bool isrefr         = lilShaderUtils.IsRefractionShaderName(material.shader.name);
-        bool isblur         = lilShaderUtils.IsBlurShaderName(material.shader.name);
-        bool isfur          = lilShaderUtils.IsFurShaderName(material.shader.name);
-        bool isonepass      = lilShaderUtils.IsOnePassShaderName(material.shader.name);
-        bool istwopass      = lilShaderUtils.IsTwoPassShaderName(material.shader.name);
+        bool islite         = lilShaderUtils.IsLiteShaderName(shaderName);
+        bool iscutout       = lilShaderUtils.IsCutoutShaderName(shaderName);
+        bool istransparent  = lilShaderUtils.IsTransparentShaderName(shaderName);
+        bool isrefr         = lilShaderUtils.IsRefractionShaderName(shaderName);
+        bool isblur         = lilShaderUtils.IsBlurShaderName(shaderName);
+        bool isfur          = lilShaderUtils.IsFurShaderName(shaderName);
+        bool isonepass      = lilShaderUtils.IsOnePassShaderName(shaderName);
+        bool istwopass      = lilShaderUtils.IsTwoPassShaderName(shaderName);
 
         var renderingMode = RenderingMode.Opaque;
 
@@ -210,19 +211,20 @@ public class lilToonPreset : ScriptableObject
             Array.Resize(ref preset.vectors, 0);
             Array.Resize(ref preset.floats, 0);
             Array.Resize(ref preset.textures, 0);
-            if(material.shader != null && !string.IsNullOrEmpty(material.shader.name))
+            string shaderName;
+            if(material.shader != null && !string.IsNullOrEmpty(shaderName = material.shader.name))
             {
-                isOutl        = lilShaderUtils.IsOutlineShaderName(material.shader.name);
-                isTess        = lilShaderUtils.IsTessellationShaderName(material.shader.name);
+                isOutl        = lilShaderUtils.IsOutlineShaderName(shaderName);
+                isTess        = lilShaderUtils.IsTessellationShaderName(shaderName);
                 renderingMode = RenderingMode.Opaque;
-                if(lilShaderUtils.IsCutoutShaderName(material.shader.name))         renderingMode = RenderingMode.Cutout;
-                if(lilShaderUtils.IsTransparentShaderName(material.shader.name))    renderingMode = RenderingMode.Transparent;
-                if(lilShaderUtils.IsRefractionShaderName(material.shader.name))     renderingMode = RenderingMode.Refraction;
-                if(lilShaderUtils.IsRefractionBlurShaderName(material.shader.name)) renderingMode = RenderingMode.RefractionBlur;
-                if(lilShaderUtils.IsFurShaderName(material.shader.name))            renderingMode = RenderingMode.Fur;
-                if(lilShaderUtils.IsFurCutoutShaderName(material.shader.name))      renderingMode = RenderingMode.FurCutout;
-                if(lilShaderUtils.IsFurTwoPassShaderName(material.shader.name))     renderingMode = RenderingMode.FurTwoPass;
-                if(lilShaderUtils.IsGemShaderName(material.shader.name))            renderingMode = RenderingMode.Gem;
+                if(lilShaderUtils.IsCutoutShaderName(shaderName))         renderingMode = RenderingMode.Cutout;
+                if(lilShaderUtils.IsTransparentShaderName(shaderName))    renderingMode = RenderingMode.Transparent;
+                if(lilShaderUtils.IsRefractionShaderName(shaderName))     renderingMode = RenderingMode.Refraction;
+                if(lilShaderUtils.IsRefractionBlurShaderName(shaderName)) renderingMode = RenderingMode.RefractionBlur;
+                if(lilShaderUtils.IsFurShaderName(shaderName))            renderingMode = RenderingMode.Fur;
+                if(lilShaderUtils.IsFurCutoutShaderName(shaderName))      renderingMode = RenderingMode.FurCutout;
+                if(lilShaderUtils.IsFurTwoPassShaderName(shaderName))     renderingMode = RenderingMode.FurTwoPass;
+                if(lilShaderUtils.IsGemShaderName(shaderName))            renderingMode = RenderingMode.Gem;
             }
             else
             {

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -994,7 +994,9 @@ public class lilToonSetting : ScriptableObject
     internal static void SetupShaderSettingFromMaterial(Material material, ref lilToonSetting shaderSetting)
     {
         if(material == null || material.shader == null) return;
-        if(lilShaderUtils.IsLiteShaderName(material.shader.name) || lilShaderUtils.IsMultiShaderName(material.shader.name)) return;
+
+        var shaderName = material.shader.name;
+        if(lilShaderUtils.IsLiteShaderName(shaderName) || lilShaderUtils.IsMultiShaderName(shaderName)) return;
         if(!lilMaterialUtils.CheckShaderIslilToon(material.shader)) return;
 
         if(!shaderSetting.LIL_FEATURE_ANIMATE_MAIN_UV && material.HasProperty("_MainTex_ScrollRotate") && material.GetVector("_MainTex_ScrollRotate") != lilConstants.defaultScrollRotate)
@@ -1037,7 +1039,7 @@ public class lilToonSetting : ScriptableObject
             shaderSetting.LIL_FEATURE_SHADOW_LUT = true;
         }
 
-        if(lilShaderUtils.IsFurShaderName(material.shader.name))
+        if(lilShaderUtils.IsFurShaderName(shaderName))
         {
             if(!shaderSetting.LIL_FEATURE_FUR_COLLISION && material.HasProperty("_FurTouchStrength") && material.GetFloat("_FurTouchStrength") != 0.0f)
             {
@@ -1247,7 +1249,7 @@ public class lilToonSetting : ScriptableObject
         }
            
         // Outline
-        if(lilShaderUtils.IsOutlineShaderName(material.shader.name))
+        if(lilShaderUtils.IsOutlineShaderName(shaderName))
         {
             if(!shaderSetting.LIL_FEATURE_ANIMATE_OUTLINE_UV && material.HasProperty("_OutlineTex_ScrollRotate") && material.GetVector("_OutlineTex_ScrollRotate") != lilConstants.defaultScrollRotate)
             {

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -994,7 +994,7 @@ public class lilToonSetting : ScriptableObject
     internal static void SetupShaderSettingFromMaterial(Material material, ref lilToonSetting shaderSetting)
     {
         if(material == null || material.shader == null) return;
-        if(material.shader.name.Contains("Lite") || material.shader.name.Contains("Multi")) return;
+        if(lilShaderUtils.IsLiteShaderName(material.shader.name) || lilShaderUtils.IsMultiShaderName(material.shader.name)) return;
         if(!lilMaterialUtils.CheckShaderIslilToon(material.shader)) return;
 
         if(!shaderSetting.LIL_FEATURE_ANIMATE_MAIN_UV && material.HasProperty("_MainTex_ScrollRotate") && material.GetVector("_MainTex_ScrollRotate") != lilConstants.defaultScrollRotate)
@@ -1037,7 +1037,7 @@ public class lilToonSetting : ScriptableObject
             shaderSetting.LIL_FEATURE_SHADOW_LUT = true;
         }
 
-        if(material.shader.name.Contains("Fur"))
+        if(lilShaderUtils.IsFurShaderName(material.shader.name))
         {
             if(!shaderSetting.LIL_FEATURE_FUR_COLLISION && material.HasProperty("_FurTouchStrength") && material.GetFloat("_FurTouchStrength") != 0.0f)
             {
@@ -1247,7 +1247,7 @@ public class lilToonSetting : ScriptableObject
         }
            
         // Outline
-        if(material.shader.name.Contains("Outline"))
+        if(lilShaderUtils.IsOutlineShaderName(material.shader.name))
         {
             if(!shaderSetting.LIL_FEATURE_ANIMATE_OUTLINE_UV && material.HasProperty("_OutlineTex_ScrollRotate") && material.GetVector("_OutlineTex_ScrollRotate") != lilConstants.defaultScrollRotate)
             {


### PR DESCRIPTION
エディタの処理にて，[シェーダー種別を特定の文字列が含まれているかどうかで判定している](https://github.com/lilxyzw/lilToon/blob/2.2.1/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs#L292-L305 "Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs")ため，カスタムシェーダーのベース名の部分文字列にそれらが含まれていると，エディタの処理で誤判定されてしまいます．
例えば， `lilToonMultiRimLight` というベース名にすると，全シェーダーバリエーションがMulti系のシェーダーと判定されてしまいます．

[lilToonInspectorの各シェーダー種別変数](https://github.com/lilxyzw/lilToon/blob/2.2.1/Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs#L122-L135 "Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs")だけの話であれば，カスタムシェーダー側の `LoadCustomProperties()` 内で上書きすることで回避できるのですが，他にもいくつかシェーダー名ベースで行っている箇所があるため，対応としては不十分になります．

この問題の回避のため，シェーダー名の最後のセパレータ `/` より後に特定の文字列が含まれるか否かを基本として判定するようにしてみました．
ただし，`Lite`, `Tessellation`, `[Optional]` 系のカスタムシェーダー名については，セパレータより後に部分文字列がないもの（具体的には下記30個のバリエーション）もあり，この判定だけでは不十分であるため，追加の判定を行うようにしています．

1. `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Opaque`
2. `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Cutout`
3. `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Transparent`
4. `Hidden/*LIL_SHADER_NAME*/Tessellation/Opaque`
5. `Hidden/*LIL_SHADER_NAME*/Tessellation/Cutout`
6. `Hidden/*LIL_SHADER_NAME*/Tessellation/Transparent`
7. `Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparent`
8. `Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparent`
9. `Hidden/*LIL_SHADER_NAME*/Tessellation/OpaqueOutline`
10. `Hidden/*LIL_SHADER_NAME*/Tessellation/CutoutOutline`
11. `Hidden/*LIL_SHADER_NAME*/Tessellation/TransparentOutline`
12. `Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparentOutline`
13. `Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparentOutline`
14. `Hidden/*LIL_SHADER_NAME*/Lite/Cutout`
15. `Hidden/*LIL_SHADER_NAME*/Lite/Transparent`
16. `Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparent`
17. `Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparent`
18. `Hidden/*LIL_SHADER_NAME*/Lite/OpaqueOutline`
19. `Hidden/*LIL_SHADER_NAME*/Lite/CutoutOutline`
20. `Hidden/*LIL_SHADER_NAME*/Lite/TransparentOutline`
21. `Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparentOutline`
22. `Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparentOutline`
23. `*LIL_SHADER_NAME*/[Optional] FurOnly/Transparent`
24. `*LIL_SHADER_NAME*/[Optional] FurOnly/Cutout`
25. `*LIL_SHADER_NAME*/[Optional] FurOnly/TwoPass`
26. `*LIL_SHADER_NAME*/[Optional] FakeShadow`
27. `*LIL_SHADER_NAME*/[Optional] Overlay`
28. `*LIL_SHADER_NAME*/[Optional] OverlayOnePass`
29. `*LIL_SHADER_NAME*/[Optional] LiteOverlay`
30. `*LIL_SHADER_NAME*/[Optional] LiteOverlayOnePass`

<details>
<summary>シェーダー名対応表（折り畳み）</summary>

| No. | `lilShaderManager` メンバ名 | シェーダー名 | シェーダー名（カスタム） |
|-|-|-|-|
| 1 | `lts` | `lilToon` | `*LIL_SHADER_NAME*/lilToon` |
| 2 | `ltsc` | `Hidden/lilToonCutout` | `Hidden/*LIL_SHADER_NAME*/Cutout` |
| 3 | `ltst` | `Hidden/lilToonTransparent` | `Hidden/*LIL_SHADER_NAME*/Transparent` |
| 4 | `ltsot` | `Hidden/lilToonOnePassTransparent` | `Hidden/*LIL_SHADER_NAME*/OnePassTransparent` |
| 5 | `ltstt` | `Hidden/lilToonTwoPassTransparent` | `Hidden/*LIL_SHADER_NAME*/TwoPassTransparent` |
| 6 | `ltso` | `Hidden/lilToonOutline` | `Hidden/*LIL_SHADER_NAME*/OpaqueOutline` |
| 7 | `ltsco` | `Hidden/lilToonCutoutOutline` | `Hidden/*LIL_SHADER_NAME*/CutoutOutline` |
| 8 | `ltsto` | `Hidden/lilToonTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/TransparentOutline` |
| 9 | `ltsoto` | `Hidden/lilToonOnePassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/OnePassTransparentOutline` |
| 10 | `ltstto` | `Hidden/lilToonTwoPassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/TwoPassTransparentOutline` |
| 11 | `ltsoo` | `_lil/[Optional] lilToonOutlineOnly` | `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Opaque` |
| 12 | `ltscoo` | `_lil/[Optional] lilToonOutlineOnlyCutout` | `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Cutout` |
| 13 | `ltstoo` | `_lil/[Optional] lilToonOutlineOnlyTransparent` | `*LIL_SHADER_NAME*/[Optional] OutlineOnly/Transparent` |
| 14 | `ltstess` | `Hidden/lilToonTessellation` | `Hidden/*LIL_SHADER_NAME*/Tessellation/Opaque` |
| 15 | `ltstessc` | `Hidden/lilToonTessellationCutout` | `Hidden/*LIL_SHADER_NAME*/Tessellation/Cutout` |
| 16 | `ltstesst` | `Hidden/lilToonTessellationTransparent` | `Hidden/*LIL_SHADER_NAME*/Tessellation/Transparent` |
| 17 | `ltstessot` | `Hidden/lilToonTessellationOnePassTransparent` | `Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparent` |
| 18 | `ltstesstt` | `Hidden/lilToonTessellationTwoPassTransparent` | `Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparent` |
| 19 | `ltstesso` | `Hidden/lilToonTessellationOutline` | `Hidden/*LIL_SHADER_NAME*/Tessellation/OpaqueOutline` |
| 20 | `ltstessco` | `Hidden/lilToonTessellationCutoutOutline` | `Hidden/*LIL_SHADER_NAME*/Tessellation/CutoutOutline` |
| 21 | `ltstessto` | `Hidden/lilToonTessellationTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Tessellation/TransparentOutline` |
| 22 | `ltstessoto` | `Hidden/lilToonTessellationOnePassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Tessellation/OnePassTransparentOutline` |
| 23 | `ltstesstto` | `Hidden/lilToonTessellationTwoPassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Tessellation/TwoPassTransparentOutline` |
| 24 | `ltsl` | `Hidden/lilToonLite` | `*LIL_SHADER_NAME*/lilToonLite` |
| 25 | `ltslc` | `Hidden/lilToonLiteCutout` | `Hidden/*LIL_SHADER_NAME*/Lite/Cutout` |
| 26 | `ltslt` | `Hidden/lilToonLiteTransparent` | `Hidden/*LIL_SHADER_NAME*/Lite/Transparent` |
| 27 | `ltslot` | `Hidden/lilToonLiteOnePassTransparent` | `Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparent` |
| 28 | `ltsltt` | `Hidden/lilToonLiteTwoPassTransparent` | `Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparent` |
| 29 | `ltslo` | `Hidden/lilToonLiteOutline` | `Hidden/*LIL_SHADER_NAME*/Lite/OpaqueOutline` |
| 30 | `ltslco` | `Hidden/lilToonLiteCutoutOutline` | `Hidden/*LIL_SHADER_NAME*/Lite/CutoutOutline` |
| 31 | `ltslto` | `Hidden/lilToonLiteTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Lite/TransparentOutline` |
| 32 | `ltsloto` | `Hidden/lilToonLiteOnePassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Lite/OnePassTransparentOutline` |
| 33 | `ltsltto` | `Hidden/lilToonLiteTwoPassTransparentOutline` | `Hidden/*LIL_SHADER_NAME*/Lite/TwoPassTransparentOutline` |
| 34 | `ltsref` | `Hidden/lilToonRefraction` | `Hidden/*LIL_SHADER_NAME*/Refraction` |
| 35 | `ltsrefb` | `Hidden/lilToonRefractionBlur` | `Hidden/*LIL_SHADER_NAME*/RefractionBlur` |
| 36 | `ltsfur` | `Hidden/lilToonFur` | `Hidden/*LIL_SHADER_NAME*/Fur` |
| 37 | `ltsfurc` | `Hidden/lilToonFurCutout` | `Hidden/*LIL_SHADER_NAME*/FurCutout` |
| 38 | `ltsfurtwo` | `Hidden/lilToonFurTwoPass` | `Hidden/*LIL_SHADER_NAME*/FurTwoPass` |
| 39 | `ltsfuro` | `_lil/[Optional] lilToonFurOnlyTransparent` | `*LIL_SHADER_NAME*/[Optional] FurOnly/Transparent` |
| 40 | `ltsfuroc` | `_lil/[Optional] lilToonFurOnlyCutout` | `*LIL_SHADER_NAME*/[Optional] FurOnly/Cutout` |
| 41 | `ltsfurotwo` | `_lil/[Optional] lilToonFurOnlyTwoPass` | `*LIL_SHADER_NAME*/[Optional] FurOnly/TwoPass` |
| 42 | `ltsgem` | `Hidden/lilToonGem` | `Hidden/*LIL_SHADER_NAME*/Gem` |
| 43 | `ltsfs` | `_lil/[Optional] lilToonFakeShadow` | `*LIL_SHADER_NAME*/[Optional] FakeShadow` |
| 44 | `ltsover` | `_lil/[Optional] lilToonOverlay` | `*LIL_SHADER_NAME*/[Optional] Overlay` |
| 45 | `ltsoover` | `_lil/[Optional] lilToonOverlayOnePass` | `*LIL_SHADER_NAME*/[Optional] OverlayOnePass` |
| 46 | `ltslover` | `_lil/[Optional] lilToonLiteOverlay` | `*LIL_SHADER_NAME*/[Optional] LiteOverlay` |
| 47 | `ltsloover` | `_lil/[Optional] lilToonLiteOverlayOnePass` | `*LIL_SHADER_NAME*/[Optional] LiteOverlayOnePass` |
| 48 | `ltsm` | `_lil/lilToonMulti` | `*LIL_SHADER_NAME*/lilToonMulti` |
| 49 | `ltsmo` | `Hidden/lilToonMultiOutline` | `Hidden/*LIL_SHADER_NAME*/MultiOutline` |
| 50 | `ltsmref` | `Hidden/lilToonMultiRefraction` | `Hidden/*LIL_SHADER_NAME*/MultiRefraction` |
| 51 | `ltsmfur` | `Hidden/lilToonMultiFur` | `Hidden/*LIL_SHADER_NAME*/MultiFur` |
| 52 | `ltsmgem` | `Hidden/lilToonMultiGem` | `Hidden/*LIL_SHADER_NAME*/MultiGem` |
| 53 | `ltsbaker` | `Hidden/ltsother_baker` |  |
| 54 | `ltspo` | `Hidden/ltspass_opaque` | `Hidden/*LIL_SHADER_NAME*/ltspass_opaque` |
| 55 | `ltspc` | `Hidden/ltspass_cutout` | `Hidden/*LIL_SHADER_NAME*/ltspass_cutout` |
| 56 | `ltspt` | `Hidden/ltspass_transparent` | `Hidden/*LIL_SHADER_NAME*/ltspass_transparent` |
| 57 | `ltsptesso` | `Hidden/ltspass_tess_opaque` | `Hidden/*LIL_SHADER_NAME*/ltspass_tess_opaque` |
| 58 | `ltsptessc` | `Hidden/ltspass_tess_cutout` | `Hidden/*LIL_SHADER_NAME*/ltspass_tess_cutout` |
| 59 | `ltsptesst` | `Hidden/ltspass_tess_transparent` | `Hidden/*LIL_SHADER_NAME*/ltspass_tess_transparent` |
| 60 |  | `Hidden/ltsother_bakeramp` |  |
| 61 |  | `Hidden/ltspass_dummy` |  |
| 62 |  | `Hidden/ltspass_lite_cutout` | `Hidden/*LIL_SHADER_NAME*/ltspass_lite_cutout` |
| 63 |  | `Hidden/ltspass_lite_opaque` | `Hidden/*LIL_SHADER_NAME*/ltspass_lite_opaque` |
| 64 |  | `Hidden/ltspass_lite_transparent` | `Hidden/*LIL_SHADER_NAME*/ltspass_lite_transparent` |
| 65 |  | `Hidden/ltspass_proponly` |  |

※ `*LIL_SHADER_NAME*` がカスタムシェーダーのベース名に置換される部分

</details>

なお，本件の改善案だけではカスタムシェーダーのベース名自体が `Lite`, `Tessellation` などのようなものになっている場合に対応ができない（全てのバリエーションがLite系やTessellation系と判定される）のですが，そのような名前が付けられることはないものとしています．
また，カスタムシェーダーの .lilcontainer のシェーダー名そのままであることを前提にしています．


2つ目のコミットは単なるリファクタリングです．
`UnityEngine.Shader.name` は [`UnityEngine.Object.name` そのもの](https://github.com/Unity-Technologies/UnityCsReference/blob/2023.3/Runtime/Export/Scripting/UnityEngineObject.bindings.cs#L175-L179 "Runtime/Export/Scripting/UnityEngineObject.bindings.cs")なので，[ネイティブ実装部分の呼び出し](https://github.com/Unity-Technologies/UnityCsReference/blob/2023.3/Runtime/Export/Scripting/UnityEngineObject.bindings.cs#L647-L648 "Runtime/Export/Scripting/UnityEngineObject.bindings.cs")が行われ，参照する度に `string` インスタンスが生成され，メモリアロケーションが発生します．
実際に試したところ，下記の結果となりました．

```cs
var s1 = shader.name;
var s2 = shader.name;
Debug.Log(object.ReferenceEquals(s1, s2));  // => false
Debug.Log(s1 == s2);  // => true
```

同一メソッド内で2回以上 `UnityEngine.Shader.name` を用いている場合は，一旦ローカル変数に格納し，使い回すようにしてみました．