### PR TITLE
fix: animated decal not properly baked #351

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilEditorTextureBaker.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilEditorTextureBaker.cs
@@ -84,6 +84,8 @@ namespace lilToon
                     hsvgMaterial.SetFloat(useMain2ndTex.name,               useMain2ndTex.floatValue);
                     hsvgMaterial.SetColor(mainColor2nd.name,                mainColor2nd.colorValue);
                     hsvgMaterial.SetFloat(main2ndTexAngle.name,             main2ndTexAngle.floatValue);
+                    hsvgMaterial.SetVector(main2ndTexDecalAnimation.name,   main2ndTexDecalAnimation.vectorValue);
+                    hsvgMaterial.SetVector(main2ndTexDecalSubParam.name,    main2ndTexDecalSubParam.vectorValue);
                     hsvgMaterial.SetFloat(main2ndTexIsDecal.name,           main2ndTexIsDecal.floatValue);
                     hsvgMaterial.SetFloat(main2ndTexIsLeftOnly.name,        main2ndTexIsLeftOnly.floatValue);
                     hsvgMaterial.SetFloat(main2ndTexIsRightOnly.name,       main2ndTexIsRightOnly.floatValue);
@@ -126,6 +128,8 @@ namespace lilToon
                     hsvgMaterial.SetFloat(useMain3rdTex.name,               useMain3rdTex.floatValue);
                     hsvgMaterial.SetColor(mainColor3rd.name,                mainColor3rd.colorValue);
                     hsvgMaterial.SetFloat(main3rdTexAngle.name,             main3rdTexAngle.floatValue);
+                    hsvgMaterial.SetVector(main3rdTexDecalAnimation.name,   main3rdTexDecalAnimation.vectorValue);
+                    hsvgMaterial.SetVector(main3rdTexDecalSubParam.name,    main3rdTexDecalSubParam.vectorValue);
                     hsvgMaterial.SetFloat(main3rdTexIsDecal.name,           main3rdTexIsDecal.floatValue);
                     hsvgMaterial.SetFloat(main3rdTexIsLeftOnly.name,        main3rdTexIsLeftOnly.floatValue);
                     hsvgMaterial.SetFloat(main3rdTexIsRightOnly.name,       main3rdTexIsRightOnly.floatValue);
@@ -238,6 +242,8 @@ namespace lilToon
                     hsvgMaterial.SetFloat(useMain2ndTex.name,               useMain2ndTex.floatValue);
                     hsvgMaterial.SetColor(mainColor2nd.name,                mainColor2nd.colorValue);
                     hsvgMaterial.SetFloat(main2ndTexAngle.name,             main2ndTexAngle.floatValue);
+                    hsvgMaterial.SetVector(main2ndTexDecalAnimation.name,   main2ndTexDecalAnimation.vectorValue);
+                    hsvgMaterial.SetVector(main2ndTexDecalSubParam.name,    main2ndTexDecalSubParam.vectorValue);
                     hsvgMaterial.SetFloat(main2ndTexIsDecal.name,           main2ndTexIsDecal.floatValue);
                     hsvgMaterial.SetFloat(main2ndTexIsLeftOnly.name,        main2ndTexIsLeftOnly.floatValue);
                     hsvgMaterial.SetFloat(main2ndTexIsRightOnly.name,       main2ndTexIsRightOnly.floatValue);
@@ -280,6 +286,8 @@ namespace lilToon
                     hsvgMaterial.SetFloat(useMain3rdTex.name,               useMain3rdTex.floatValue);
                     hsvgMaterial.SetColor(mainColor3rd.name,                mainColor3rd.colorValue);
                     hsvgMaterial.SetFloat(main3rdTexAngle.name,             main3rdTexAngle.floatValue);
+                    hsvgMaterial.SetVector(main3rdTexDecalAnimation.name,   main3rdTexDecalAnimation.vectorValue);
+                    hsvgMaterial.SetVector(main3rdTexDecalSubParam.name,    main3rdTexDecalSubParam.vectorValue);
                     hsvgMaterial.SetFloat(main3rdTexIsDecal.name,           main3rdTexIsDecal.floatValue);
                     hsvgMaterial.SetFloat(main3rdTexIsLeftOnly.name,        main3rdTexIsLeftOnly.floatValue);
                     hsvgMaterial.SetFloat(main3rdTexIsRightOnly.name,       main3rdTexIsRightOnly.floatValue);

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -193,6 +193,8 @@ CBUFFER_START(UnityPerMaterial)
     uint    _Main3rdTex_UVMode;
     uint    _AlphaMaskMode;
     lilBool _UseMain2ndTex;
+    float4 _Main2ndTexDecalAnimation;
+    float4 _Main2ndTexDecalSubParam;
     lilBool _Main2ndTexIsDecal;
     lilBool _Main2ndTexIsLeftOnly;
     lilBool _Main2ndTexIsRightOnly;
@@ -201,6 +203,8 @@ CBUFFER_START(UnityPerMaterial)
     lilBool _Main2ndTexShouldFlipCopy;
     lilBool _Main2ndTexIsMSDF;
     lilBool _UseMain3rdTex;
+    float4 _Main3rdTexDecalAnimation;
+    float4 _Main3rdTexDecalSubParam;
     lilBool _Main3rdTexIsDecal;
     lilBool _Main3rdTexIsLeftOnly;
     lilBool _Main3rdTexIsRightOnly;

--- a/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_macro.hlsl
@@ -2321,11 +2321,11 @@ struct lilLightData
 
 // Main Color & Emission
 #if defined(LIL_BAKER)
-    #define LIL_GET_SUBTEX(tex,uv)  lilGetSubTexWithoutAnimation(tex, tex##_ST, tex##_ScrollRotate, tex##Angle, uv, 1, tex##IsDecal, tex##IsLeftOnly, tex##IsRightOnly, tex##ShouldCopy, tex##ShouldFlipMirror, tex##ShouldFlipCopy, tex##IsMSDF, isRightHand LIL_SAMP_IN(sampler##tex))
+    #define LIL_GET_SUBTEX(tex,uv)  lilGetSubTexWithoutAnimation(tex, tex##_ST, tex##_ScrollRotate, tex##Angle, uv, 1, tex##IsDecal, tex##IsLeftOnly, tex##IsRightOnly, tex##ShouldCopy, tex##ShouldFlipMirror, tex##ShouldFlipCopy, tex##IsMSDF, isRightHand, tex##DecalAnimation, tex##DecalSubParam LIL_SAMP_IN(sampler##tex))
     #define LIL_GET_EMITEX(tex,uv)  LIL_SAMPLE_2D(tex, sampler##tex, lilCalcUVWithoutAnimation(uv, tex##_ST, tex##_ScrollRotate))
     #define LIL_GET_EMIMASK(tex,uv) LIL_SAMPLE_2D(tex, sampler_MainTex, lilCalcUVWithoutAnimation(uv, tex##_ST, tex##_ScrollRotate))
 #elif defined(LIL_WITHOUT_ANIMATION)
-    #define LIL_GET_SUBTEX(tex,uv)  lilGetSubTexWithoutAnimation(tex, tex##_ST, tex##_ScrollRotate, tex##Angle, uv, 1, tex##IsDecal, tex##IsLeftOnly, tex##IsRightOnly, tex##ShouldCopy, tex##ShouldFlipMirror, tex##ShouldFlipCopy, tex##IsMSDF, fd.isRightHand LIL_SAMP_IN(sampler##tex))
+    #define LIL_GET_SUBTEX(tex,uv)  lilGetSubTexWithoutAnimation(tex, tex##_ST, tex##_ScrollRotate, tex##Angle, uv, 1, tex##IsDecal, tex##IsLeftOnly, tex##IsRightOnly, tex##ShouldCopy, tex##ShouldFlipMirror, tex##ShouldFlipCopy, tex##IsMSDF, fd.isRightHand, tex##DecalAnimation, tex##DecalSubParam LIL_SAMP_IN(sampler##tex))
     #define LIL_GET_EMITEX(tex,uv)  LIL_SAMPLE_2D(tex, sampler##tex, lilCalcUVWithoutAnimation(uv, tex##_ST, tex##_ScrollRotate))
     #define LIL_GET_EMIMASK(tex,uv) LIL_SAMPLE_2D(tex, sampler_MainTex, lilCalcUVWithoutAnimation(uv, tex##_ST, tex##_ScrollRotate))
 #else

--- a/Assets/lilToon/Shader/ltspass_baker.shader
+++ b/Assets/lilToon/Shader/ltspass_baker.shader
@@ -18,6 +18,8 @@ Shader "Hidden/ltsother_baker"
                         _Color2nd                   ("Color", Color) = (1,1,1,1)
                         _Main2ndTex                 ("Texture", 2D) = "white" {}
         [lilAngle]      _Main2ndTexAngle            ("Angle", Float) = 0
+        [lilDecalAnim]  _Main2ndTexDecalAnimation   ("sDecalAnimations", Vector) = (1,1,1,30)
+        [lilDecalSub]   _Main2ndTexDecalSubParam    ("sDecalSubParams", Vector) = (1,1,0,1)
         [lilToggle]     _Main2ndTexIsDecal          ("As Decal", Int) = 0
         [lilToggle]     _Main2ndTexIsLeftOnly       ("Left Only", Int) = 0
         [lilToggle]     _Main2ndTexIsRightOnly      ("Right Only", Int) = 0
@@ -34,6 +36,8 @@ Shader "Hidden/ltsother_baker"
                         _Color3rd                   ("Color", Color) = (1,1,1,1)
                         _Main3rdTex                 ("Texture", 2D) = "white" {}
         [lilAngle]      _Main3rdTexAngle            ("Angle", Float) = 0
+        [lilDecalAnim]  _Main3rdTexDecalAnimation   ("sDecalAnimations", Vector) = (1,1,1,30)
+        [lilDecalSub]   _Main3rdTexDecalSubParam    ("sDecalSubParams", Vector) = (1,1,0,1)
         [lilToggle]     _Main3rdTexIsDecal          ("As Decal", Int) = 0
         [lilToggle]     _Main3rdTexIsLeftOnly       ("Left Only", Int) = 0
         [lilToggle]     _Main3rdTexIsRightOnly      ("Right Only", Int) = 0


### PR DESCRIPTION
#351 の修正です。
アニメーションするデカールを焼き込む場合、テクスチャ全体ではなくanimTime=0 (1フレーム目)の範囲を焼き込みます。

fix #351