### PR TITLE
Add UVMode for rim light texture

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -294,6 +294,7 @@
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
@@ -294,6 +294,7 @@
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("Blend Main", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
@@ -311,6 +311,7 @@ namespace lilToon
         private readonly lilMaterialProperty useRim                 = new lilMaterialProperty("_UseRim", PropertyBlock.RimLight);
         private readonly lilMaterialProperty rimColor               = new lilMaterialProperty("_RimColor", PropertyBlock.RimLight);
         private readonly lilMaterialProperty rimColorTex            = new lilMaterialProperty("_RimColorTex", true, PropertyBlock.RimLight);
+        private readonly lilMaterialProperty rimColorTex_UVMode     = new lilMaterialProperty("_RimColorTex_UVMode", true, PropertyBlock.RimLight);
         private readonly lilMaterialProperty rimMainStrength        = new lilMaterialProperty("_RimMainStrength", PropertyBlock.RimLight);
         private readonly lilMaterialProperty rimNormalStrength      = new lilMaterialProperty("_RimNormalStrength", PropertyBlock.RimLight);
         private readonly lilMaterialProperty rimBorder              = new lilMaterialProperty("_RimBorder", PropertyBlock.RimLight);
@@ -920,6 +921,7 @@ namespace lilToon
                 useRim,
                 rimColor,
                 rimColorTex,
+                rimColorTex_UVMode,
                 rimMainStrength,
                 rimNormalStrength,
                 rimBorder,

--- a/Assets/lilToon/Editor/lilInspector/lilPropertyGroupDrawerNormalMapAndReflectionSetting.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilPropertyGroupDrawerNormalMapAndReflectionSetting.cs
@@ -133,7 +133,7 @@ namespace lilToon
                     if(useRim.floatValue == 1)
                     {
                         EditorGUILayout.BeginVertical(boxInnerHalf);
-                        TextureGUI(ref edSet.isShowRimColorTex, colorMaskRGBAContent, rimColorTex, rimColor);
+                        TextureGUI(ref edSet.isShowRimColorTex, colorMaskRGBAContent, rimColorTex, rimColor, rimColorTex_UVMode, "UV Mode|UV0|UV1|UV2|UV3");
                         LocalizedPropertyAlpha(rimColor);
                         LocalizedProperty(rimMainStrength);
                         LocalizedProperty(rimEnableLighting);

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -1649,7 +1649,11 @@
                 float4 rimColor = _RimColor;
                 float4 rimIndirColor = _RimIndirColor;
                 #if defined(LIL_FEATURE_RimColorTex)
-                    float4 rimColorTex = LIL_SAMPLE_2D_ST(_RimColorTex, samp, fd.uvMain);
+                    float2 uvRimColor = fd.uvMain;
+                    if(_RimColorTex_UVMode == 1) uvRimColor = fd.uv1;
+                    if(_RimColorTex_UVMode == 2) uvRimColor = fd.uv2;
+                    if(_RimColorTex_UVMode == 3) uvRimColor = fd.uv3;
+                    float4 rimColorTex = LIL_SAMPLE_2D_ST(_RimColorTex, samp, uvRimColor);
                     rimColor *= rimColorTex;
                     rimIndirColor *= rimColorTex;
                 #endif
@@ -1699,7 +1703,11 @@
                 // Color
                 float4 rimColor = _RimColor;
                 #if defined(LIL_FEATURE_RimColorTex)
-                    rimColor *= LIL_SAMPLE_2D_ST(_RimColorTex, samp, fd.uvMain);
+                    float2 uvRimColor = fd.uvMain;
+                    if(_RimColorTex_UVMode == 1) uvRimColor = fd.uv1;
+                    if(_RimColorTex_UVMode == 2) uvRimColor = fd.uv2;
+                    if(_RimColorTex_UVMode == 3) uvRimColor = fd.uv3;
+                    rimColor *= LIL_SAMPLE_2D_ST(_RimColorTex, samp, uvRimColor);
                 #endif
                 rimColor.rgb = lerp(rimColor.rgb, rimColor.rgb * fd.albedo, _RimMainStrength);
 

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -688,6 +688,7 @@ CBUFFER_START(UnityPerMaterial)
     #endif
     #if defined(LIL_MULTI_INPUTS_RIM)
         uint    _RimBlendMode;
+        uint    _RimColorTex_UVMode;
     #endif
     #if defined(LIL_MULTI_INPUTS_MATCAP)
         uint    _MatCapBlendMode;

--- a/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_base.hlsl
@@ -619,6 +619,7 @@ uint    _Cull;
 #endif
 #if defined(LIL_FEATURE_RIMLIGHT)
     uint    _RimBlendMode;
+    uint    _RimColorTex_UVMode;
 #endif
 #if defined(LIL_FEATURE_GLITTER)
     uint    _GlitterUVMode;

--- a/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input_opt.hlsl
@@ -619,6 +619,7 @@ uint    _Cull;
 #endif
 #if defined(LIL_FEATURE_RIMLIGHT)
     uint    _RimBlendMode;
+    uint    _RimColorTex_UVMode;
 #endif
 #if defined(LIL_FEATURE_GLITTER)
     uint    _GlitterUVMode;

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -298,6 +298,7 @@ Shader "lilToon"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonCutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonCutoutOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonFur"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonFurCutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonFurTwoPass"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonGem"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonOnePassTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonOverlay"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonRefraction"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonRefractionBlur"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellation"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationCutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -298,6 +298,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTwoPassTransparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -298,6 +298,7 @@ Shader "_lil/lilToonMulti"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonMultiFur"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonMultiGem"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonMultiOutline"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -298,6 +298,7 @@ Shader "Hidden/lilToonMultiRefraction"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_cutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_opaque"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_proponly.shader
+++ b/Assets/lilToon/Shader/ltspass_proponly.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_proponly"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("Blend Main", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_tess_cutout"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_tess_opaque"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_tess_transparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -298,6 +298,7 @@ Shader "Hidden/ltspass_transparent"
         [lilToggleLeft] _UseRim                     ("sRimLight", Int) = 0
         [lilHDR]        _RimColor                   ("sColor", Color) = (0.66,0.5,0.48,1)
         [NoScaleOffset] _RimColorTex                ("Texture", 2D) = "white" {}
+        [lilEnum]       _RimColorTex_UVMode         ("UV Mode|UV0|UV1|UV2|UV3", Int) = 0
                         _RimMainStrength            ("sMainColorPower", Range(0, 1)) = 0
                         _RimNormalStrength          ("sNormalStrength", Range(0, 1)) = 1.0
                         _RimBorder                  ("sBorder", Range(0, 1)) = 0.5


### PR DESCRIPTION
This allows selecting which UV layer to use for the rim light color/mask texture.

My model is already configured for UV tile discard, and this feature allows me to use a small (32x) mask texture to mask based on UV tiles instead of a higher-resolution mask on the base UVs.

For example, this setting masks UV1 row 0 tiles 1+2.
<img width="395" height="117" alt="image" src="https://github.com/user-attachments/assets/9e9b68cb-bcb3-4432-bcfc-7393df714300" />
