### PR TITLE
fix: Copy texture _ST properties in material property copy/paste #367

### DIFF
--- a/Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilEditorVariables.cs
@@ -140,6 +140,7 @@ namespace lilToon
         private static lilToonSetting shaderSetting;
         private static readonly lilToonVersion latestVersion = new() { version = "" };
         private static readonly Dictionary<string, MaterialProperty> copiedProperties = new Dictionary<string, MaterialProperty>();
+        private static readonly Dictionary<string, Vector4> copiedVectorProperties = new Dictionary<string, Vector4>();
         private static bool isCustomEditor = false;
         private static bool isMultiVariants = false;
         private readonly Gradient mainGrad  = new Gradient();

--- a/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilGUIUtility.cs
@@ -342,17 +342,28 @@ namespace lilToon
 
         private void CopyProperties(PropertyBlock propertyBlock)
         {
+            var material = (Material)m_MaterialEditor.target;
             foreach(var p in AllProperties().Where(p =>
                 p.p != null &&
                 p.blocks.Contains(propertyBlock)
             ))
             {
                 copiedProperties[p.name] = p.p;
+
+                if(p.isTexture)
+                {
+                    string stPropertyName = p.name + "_ST";
+                    if(material.HasProperty(stPropertyName))
+                    {
+                        copiedVectorProperties[stPropertyName] = material.GetVector(stPropertyName);
+                    }
+                }
             }
         }
 
         private void PasteProperties(PropertyBlock propertyBlock, bool shouldCopyTex)
         {
+            var material = (Material)m_MaterialEditor.target;
             foreach(var p in AllProperties().Where(p =>
                 p.p != null &&
                 p.blocks.Contains(propertyBlock) &&
@@ -367,6 +378,15 @@ namespace lilToon
                 if(propType == ShaderPropertyType.Float)   p.floatValue = copiedProperties[p.name].floatValue;
                 if(propType == ShaderPropertyType.Range)   p.floatValue = copiedProperties[p.name].floatValue;
                 if(propType == ShaderPropertyType.Texture) p.textureValue = copiedProperties[p.name].textureValue;
+
+                if(p.isTexture && shouldCopyTex)
+                {
+                    string stPropertyName = p.name + "_ST";
+                    if(copiedVectorProperties.ContainsKey(stPropertyName) && material.HasProperty(stPropertyName))
+                    {
+                        material.SetVector(stPropertyName, copiedVectorProperties[stPropertyName]);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
# Fix: Copy texture _ST properties in material property copy/paste

## 概要

マテリアルのプロパティコピー機能で、テクスチャの `_ST` プロパティ（Tiling/Offset）がコピーされない不具合を修正しました。

Fixes #367

## 問題

`sCopy` 機能を使用してマテリアルプロパティをコピーする際、以下のプロパティがコピーされませんでした。

- `_Main2ndTex_ST` (x, y, z, w)
- `_Main3rdTex_ST` (x, y, z, w)
- その他のテクスチャの `_ST` プロパティ

これらのプロパティは `MaterialProperty` 配列に含まれておらず、`CopyProperties` / `PasteProperties` メソッドでスキップされているようでした。

## 変更内容

### 1. `lilEditorVariables.cs`
- `copiedVectorProperties` ディクショナリを追加しました。（`_ST` プロパティの値を保存するため）

### 2. `lilGUIUtility.cs`

#### `CopyProperties` メソッド
- すべてのテクスチャプロパティに対して、対応する `_ST` プロパティを自動検出するようにしました。
- マテリアルに存在する場合のみ、`copiedVectorProperties` に保存します。

#### `PasteProperties` メソッド
- テクスチャ付きでペースト（`shouldCopyTex = true`）の場合、`_ST` プロパティも復元するようにしました。
- マテリアルに存在する `_ST` プロパティのみをペーストします。

## 設計

### 実装
_Main2ndTex_ST, _Main3rdTex_STなど特定のプロパティをハードコーディングせず、すべてのテクスチャプロパティに対して自動的に `_ST` を処理するようにしました。

**対象となる `_ST` プロパティの例：**
- `_Main2ndTex_ST`
- `_Main3rdTex_ST`
- `_Main2ndDissolveMask_ST`
- `_Main2ndDissolveNoiseMask_ST`
- `_Main3rdDissolveMask_ST`
- `_Main3rdDissolveNoiseMask_ST`

### 既存機能への影響
- **破壊的変更なし**: 既存の `copiedProperties` は変更せず、新しいディクショナリを追加しました。
- **後方互換性**: 既存のコピー/ペースト機能の動作は保持しています。

## テスト

### 手動テスト実施内容
1. Main 2nd Texture と Main 3rd Texture を使用したlilToonのマテリアルを作成
2. _Main2ndTex_ST, _Main3rdTex_ST, _Main2ndDissolveMask_ST, _Main3rdDissolveMask_ST, _Main2ndDissolveNoiseMask_ST, _Main3rdDissolveNoiseMask_ST のTiling/Offset を設定（デフォルト値から変更）
3. `sCopy` 機能でプロパティをコピー
4. 別のマテリアルに「Paste With Texture」でペースト
5. Tiling/Offset が正しくコピーされることを確認

### 確認した動作
- ✅ `_Main2ndTex_ST` が正しくコピーされる
- ✅ `_Main3rdTex_ST` が正しくコピーされる
- ✅ `_Main2ndDissolveMask_ST` が正しくコピーされる
- ✅ `_Main3rdDissolveMask_ST` が正しくコピーされる
- ✅ `_Main2ndDissolveNoiseMask_ST` が正しくコピーされる
- ✅ `_Main3rdDissolveNoiseMask_ST` が正しくコピーされる
- ✅ 「Paste」（テクスチャなし）では `_ST` はコピーされない
- ✅ 「Paste With Texture」では `_ST` もコピーされる

## スクリーンショット
### Before
Main 2nd Texture について正しく_STがコピー＆ペーストされているかを確認した際のスクリーンショットです。   
Main 3rd Textureについても同様の確認を実施し問題がないことを確認しています。
<img width="1103" height="953" alt="before" src="https://github.com/user-attachments/assets/d730ba33-0e62-4dec-87a4-9c897f3def34" />

### After
<img width="1108" height="948" alt="after" src="https://github.com/user-attachments/assets/9b6b83d5-8878-4676-97b9-15a8a695304d" />
