### PR TITLE
fix: changed to replace escaped line break codes in substitution definitions with the platform's line break codes

### DIFF
--- a/Assets/lilToon/Editor/lilShaderContainerImporter.cs
+++ b/Assets/lilToon/Editor/lilShaderContainerImporter.cs
@@ -848,7 +848,9 @@ namespace lilToon
 
         private static string FixNewlineCode(string text)
         {
-            return text.Replace("\\r", "\r").Replace("\\n", "\n");
+            return text.Replace("\\r\\n", Environment.NewLine)
+                .Replace("\\r", Environment.NewLine)
+                .Replace("\\n", Environment.NewLine);
         }
 
         private static void FixIncludeForOldUnity(ref StringBuilder sb)


### PR DESCRIPTION
Linuxにおいてのカスタムシェーダーのlilcontainerファイルの読み込みの改善案です．
`lilCustomShaderDatas.lilblock` 中のReplaceタグにおける改行コードが

- `\r\n`
- `\n`
- `\r`

のいずれであったとしても，システムの改行コード (`Environment.NewLine`) として扱うようにする変更になっています．

ジオメトリシェーダーを用いたカスタムシェーダー作例 (`lilToonGeometryFX_1.0.2.unitypackage`) 中の `lilCustomShaderDatas.lilblock` では下記の置換定義の記述があります．

```
Replace "            #pragma vertex vert\r\n            #pragma fragment frag\r\n" "            #pragma vertex vertCustom\r\n            #pragma geometry geomCustom\r\n            #pragma fragment frag\r\n            #pragma require geometry\r\n"
Replace "            #pragma vertex vertTess\r\n            #pragma fragment frag\r\n            #pragma hull hull\r\n            #pragma domain domain\r\n            #pragma require tesshw tessellation\r\n" "            #pragma vertex vertTess\r\n            #pragma fragment frag\r\n            #pragma hull hull\r\n            #pragma domain domainCustom\r\n            #pragma geometry geomCustom\r\n            #pragma require tesshw tessellation geometry\r\n"
```

改行コードに `\r\n` が指定されており，置換を行う際に[実改行コードに置き換え](https://github.com/lilxyzw/lilToon/blob/2.3.2/Assets/lilToon/Editor/lilShaderContainerImporter.cs#L849-L852 "Assets/lilToon/Editor/lilShaderContainerImporter.cs#L849-L852")ていますが，これはWindowsでなければ動作しません．
Linuxにおいては lilcontainer ファイルの読み込みに[`StringBuilfer.AppendLine()メソッド`](https://learn.microsoft.com/en-us/dotnet/api/system.text.stringbuilder.appendline "StringBuilder.AppendLine Method (System.Text) | Microsoft Learn")を[用いている](https://github.com/lilxyzw/lilToon/blob/2.3.2/Assets/lilToon/Editor/lilShaderContainerImporter.cs#L605-L675 "Assets/lilToon/Editor/lilShaderContainerImporter.cs#L605-L675")ため，置換対象の `StringBuffer` 内の改行コードは環境依存となっています．
すなわち，Linuxにおいては改行コードが `\n` となっており， `\r\n` ではマッチしないため，置換が行われず，ジオメトリシェーダーの差し込みができません．

カスタムシェーダーの `lilCustomShaderDatas.lilblock` 側で下記2行を先に記述しておき，

```
Replace "\r\n" "\n"
Replace "\r" "\n"
```

後の定義では改行を `\n` で記述する，あるいは

```
Replace "            #pragma vertex vert\r\n            #pragma fragment frag\r\n" "            #pragma vertex vertCustom\r\n            #pragma geometry geomCustom\r\n            #pragma fragment frag\r\n            #pragma require geometry\r\n"
Replace "            #pragma vertex vert\n            #pragma fragment frag\n" "            #pragma vertex vertCustom\n            #pragma geometry geomCustom\n            #pragma fragment frag\n            #pragma require geometry\n"
Replace "            #pragma vertex vert\r            #pragma fragment frag\r" "            #pragma vertex vertCustom\r            #pragma geometry geomCustom\r            #pragma fragment frag\r            #pragma require geometry\r"
Replace "            #pragma vertex vertTess\r\n            #pragma fragment frag\r\n            #pragma hull hull\r\n            #pragma domain domain\r\n            #pragma require tesshw tessellation\r\n" "            #pragma vertex vertTess\r\n            #pragma fragment frag\r\n            #pragma hull hull\r\n            #pragma domain domainCustom\r\n            #pragma geometry geomCustom\r\n            #pragma require tesshw tessellation geometry\r\n"
Replace "            #pragma vertex vertTess\n            #pragma fragment frag\n            #pragma hull hull\n            #pragma domain domain\n            #pragma require tesshw tessellation\n" "            #pragma vertex vertTess\n            #pragma fragment frag\n            #pragma hull hull\n            #pragma domain domainCustom\n            #pragma geometry geomCustom\n            #pragma require tesshw tessellation geometry\n"
Replace "            #pragma vertex vertTess\r            #pragma fragment frag\r            #pragma hull hull\r            #pragma domain domain\r            #pragma require tesshw tessellation\r" "            #pragma vertex vertTess\r            #pragma fragment frag\r            #pragma hull hull\r            #pragma domain domainCustom\r            #pragma geometry geomCustom\r            #pragma require tesshw tessellation geometry\r"
```

のように同じ置換定義を3種の改行コード用に記述するといったカスタムシェーダー側での対応でも回避可能ではあります．

ただ，本PRのように本体側で改行コードの差を吸収すれば，カスタムシェーダー作成者にとって考慮漏れがなくなるのではないかと考えています．