### PR TITLE
fix: HSVG not applied to fur #372

### DIFF
--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -307,7 +307,7 @@
 
 //------------------------------------------------------------------------------------------------------------------------------
 // Main Texture
-#if defined(LIL_PASS_FORWARD_NORMAL_INCLUDED)
+#if defined(LIL_PASS_FORWARD_NORMAL_INCLUDED) || defined(LIL_PASS_FORWARD_FUR_INCLUDED)
     #define LIL_GET_MAIN_TEX \
         fd.col = LIL_SAMPLE_2D_POM(_MainTex, sampler_MainTex, fd.uvMain, fd.ddxMain, fd.ddyMain);
 


### PR DESCRIPTION
In `lil_pass_forward_fur.hlsl`, [tone correction and gradient mapping are not enabled](https://github.com/lilxyzw/lilToon/blob/2.3.2/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl#L310-L351 "Assets/lilToon/Shader/Includes/lil_common_frag.hlsl#L310-L351"). Therefore, if you are performing these operations, color discrepancies will occur between the regular mesh and the fur mesh.

This pull request enables tone correction and gradient maps in the fur fragment shader as well.

## Screenshots

### Before fix

[![Screenshot before fixing #372](https://raw.githubusercontent.com/wiki/koturn/lilToon/image/issue372_lilToon2.3.2_before_fix.png)](https://raw.githubusercontent.com/wiki/koturn/lilToon/image/issue372_lilToon2.3.2_before_fix.png "Screenshot before fixing #372")

### After fix

[![Screenshot after fixing #372](https://raw.githubusercontent.com/wiki/koturn/lilToon/image/issue372_lilToon2.3.2_after_fix.png)](https://raw.githubusercontent.com/wiki/koturn/lilToon/image/issue372_lilToon2.3.2_after_fix.png "Screenshot after fixing #372")

---

- fix: #372