### PR TITLE
fix: Exception is thrown if lilToonSetting.json is empty

### DIFF
--- a/Assets/lilToon/Editor/lilConstants.cs
+++ b/Assets/lilToon/Editor/lilConstants.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -15,9 +16,22 @@ namespace lilToon
         {
             if (version == null)
             {
-                version = new lilToonInspector.lilToonVersion();
-                EditorJsonUtility.FromJsonOverwrite(File.ReadAllText(lilDirectoryManager.GetPackageJsonPath()), version);
-                version.semver = new SemVerParser(version.version);
+                var v = new lilToonInspector.lilToonVersion();
+                try
+                {
+                    EditorJsonUtility.FromJsonOverwrite(File.ReadAllText(lilDirectoryManager.GetPackageJsonPath()), v);
+                    v.semver = new SemVerParser(v.version);
+                    version = v;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                    Debug.Log("[lilToon] GetFromPackage() failed");
+
+                    v.version = "0.0.0";
+                    v.semver = new SemVerParser(v.version);
+                    return v;
+                }
             }
             return version;
         }

--- a/Assets/lilToon/Editor/lilRenderPipelineReader.cs
+++ b/Assets/lilToon/Editor/lilRenderPipelineReader.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -110,8 +111,16 @@ namespace lilToon
             string path = AssetDatabase.GUIDToAssetPath(guid);
             if(!string.IsNullOrEmpty(path))
             {
-                var package = JsonUtility.FromJson<PackageInfos>(File.ReadAllText(path));
-                version = package.version;
+                try
+                {
+                    var package = JsonUtility.FromJson<PackageInfos>(File.ReadAllText(path));
+                    version = package.version;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                    Debug.Log("[lilToon] ReadVersion() failed");
+                }
             }
 
             PackageVersionInfos infos;

--- a/Assets/lilToon/Editor/lilToonEditorUtils.cs
+++ b/Assets/lilToon/Editor/lilToonEditorUtils.cs
@@ -734,8 +734,16 @@ namespace lilToon
             string path = AssetDatabase.GUIDToAssetPath(guid);
             if(!string.IsNullOrEmpty(path))
             {
-                var package = JsonUtility.FromJson<PackageInfos>(File.ReadAllText(path));
-                return package.version;
+                try
+                {
+                    var package = JsonUtility.FromJson<PackageInfos>(File.ReadAllText(path));
+                    return package.version;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                    Debug.Log("[lilToon] ReadVersion() failed");
+                }
             }
             return null;
         }

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -215,7 +215,18 @@ public class lilToonSetting : ScriptableObject
     {
         string shaderSettingPath = lilDirectoryManager.GetShaderSettingPath();
         if(shaderSetting == null) shaderSetting = CreateInstance<lilToonSetting>();
-        if(File.Exists(shaderSettingPath)) JsonUtility.FromJsonOverwrite(File.ReadAllText(shaderSettingPath), shaderSetting);
+        if(File.Exists(shaderSettingPath))
+        {
+            try
+            {
+                JsonUtility.FromJsonOverwrite(File.ReadAllText(shaderSettingPath), shaderSetting);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+                Debug.Log("[lilToon] LoadShaderSetting() failed");
+            }
+        }
         LoadLockedSetting(ref shaderSetting);
     }
 

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -174,7 +174,12 @@ public class lilToonSetting : ScriptableObject
     {
         var lockedSetting = CreateInstance<lilToonSetting>();
         string path = lilDirectoryManager.GetSettingLockPath();
-        if(File.Exists(path))
+        if(!File.Exists(path))
+        {
+            return;
+        }
+
+        try
         {
             JsonUtility.FromJsonOverwrite(File.ReadAllText(path), lockedSetting);
             shaderSetting.LIL_OPTIMIZE_APPLY_SHADOW_FA       = lockedSetting.LIL_OPTIMIZE_APPLY_SHADOW_FA;
@@ -191,6 +196,11 @@ public class lilToonSetting : ScriptableObject
             shaderSetting.furLightModeName                   = lockedSetting.furLightModeName;
             shaderSetting.furPreLightModeName                = lockedSetting.furPreLightModeName;
             shaderSetting.gemPreLightModeName                = lockedSetting.gemPreLightModeName;
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+            Debug.Log("[lilToon] LoadLockedSetting() failed");
         }
     }
 


### PR DESCRIPTION
Add exception handling to the calls to `JsonUtility.FromJsonOverwrite()` and `JsonUtility.FromJson()`.

---

- fix: #385