### PR TITLE
feat: DistanceFadeMask

### DIFF
--- a/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/Default.lilblock
@@ -425,6 +425,7 @@
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
+++ b/Assets/lilToon/CustomShaderResources/Properties/DefaultAll.lilblock
@@ -425,6 +425,7 @@
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Editor/lilInspector/lilMainInspectorGUI.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMainInspectorGUI.cs
@@ -1125,6 +1125,7 @@ namespace lilToon
                         EditorGUI.indentLevel++;
                         LocalizedProperty(distanceFade);
                         LocalizedProperty(distanceFadeMode);
+                        LocalizedPropertyTexture(maskBlendContent, distanceFadeMask);
                         EditorGUI.indentLevel--;
                         DrawLine();
                         EditorGUILayout.LabelField(GetLoc("sRimLight"));

--- a/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
+++ b/Assets/lilToon/Editor/lilInspector/lilMaterialProperties.cs
@@ -388,6 +388,7 @@ namespace lilToon
         private readonly lilMaterialProperty distanceFade                = new lilMaterialProperty("_DistanceFade", PropertyBlock.DistanceFade);
         private readonly lilMaterialProperty distanceFadeColor           = new lilMaterialProperty("_DistanceFadeColor", PropertyBlock.DistanceFade);
         private readonly lilMaterialProperty distanceFadeMode            = new lilMaterialProperty("_DistanceFadeMode", PropertyBlock.DistanceFade);
+        private readonly lilMaterialProperty distanceFadeMask            = new lilMaterialProperty("_DistanceFadeMask", true, PropertyBlock.DistanceFade);
         private readonly lilMaterialProperty distanceFadeRimColor        = new lilMaterialProperty("_DistanceFadeRimColor", PropertyBlock.DistanceFade);
         private readonly lilMaterialProperty distanceFadeRimFresnelPower = new lilMaterialProperty("_DistanceFadeRimFresnelPower", PropertyBlock.DistanceFade);
 
@@ -997,6 +998,7 @@ namespace lilToon
                 distanceFade,
                 distanceFadeColor,
                 distanceFadeMode,
+                distanceFadeMask,
                 distanceFadeRimColor,
                 distanceFadeRimFresnelPower,
 

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -111,6 +111,7 @@ public class lilToonSetting : ScriptableObject
     public bool LIL_FEATURE_Emission2ndBlendMask = true;
     public bool LIL_FEATURE_Emission2ndGradTex = true;
     public bool LIL_FEATURE_ParallaxMap = true;
+    public bool LIL_FEATURE_DistanceFadeMask = true;
     public bool LIL_FEATURE_AudioLinkMask = true;
     public bool LIL_FEATURE_AudioLinkLocalMap = true;
     public bool LIL_FEATURE_DissolveMask = true;
@@ -337,6 +338,7 @@ public class lilToonSetting : ScriptableObject
         shaderSetting.LIL_FEATURE_Emission2ndBlendMask = false;
         shaderSetting.LIL_FEATURE_Emission2ndGradTex = false;
         shaderSetting.LIL_FEATURE_ParallaxMap = false;
+        shaderSetting.LIL_FEATURE_DistanceFadeMask = false;
         shaderSetting.LIL_FEATURE_AudioLinkMask = false;
         shaderSetting.LIL_FEATURE_AudioLinkLocalMap = false;
         shaderSetting.LIL_FEATURE_DissolveMask = false;
@@ -450,6 +452,7 @@ public class lilToonSetting : ScriptableObject
             shaderSetting.LIL_FEATURE_Emission2ndBlendMask = true;
             shaderSetting.LIL_FEATURE_Emission2ndGradTex = true;
             shaderSetting.LIL_FEATURE_ParallaxMap = true;
+            shaderSetting.LIL_FEATURE_DistanceFadeMask = true;
             shaderSetting.LIL_FEATURE_AudioLinkMask = true;
             shaderSetting.LIL_FEATURE_AudioLinkLocalMap = true;
             shaderSetting.LIL_FEATURE_DissolveMask = true;
@@ -668,6 +671,7 @@ public class lilToonSetting : ScriptableObject
         if (shaderSetting.LIL_FEATURE_Emission2ndBlendMask) sb.AppendLine("#define LIL_FEATURE_Emission2ndBlendMask");
         if (shaderSetting.LIL_FEATURE_Emission2ndGradTex) sb.AppendLine("#define LIL_FEATURE_Emission2ndGradTex");
         if (shaderSetting.LIL_FEATURE_ParallaxMap) sb.AppendLine("#define LIL_FEATURE_ParallaxMap");
+        if (shaderSetting.LIL_FEATURE_DistanceFadeMask) sb.AppendLine("#define LIL_FEATURE_DistanceFadeMask");
         if (shaderSetting.LIL_FEATURE_AudioLinkMask) sb.AppendLine("#define LIL_FEATURE_AudioLinkMask");
         if (shaderSetting.LIL_FEATURE_AudioLinkLocalMap) sb.AppendLine("#define LIL_FEATURE_AudioLinkLocalMap");
         if (shaderSetting.LIL_FEATURE_DissolveMask) sb.AppendLine("#define LIL_FEATURE_DissolveMask");
@@ -1425,6 +1429,7 @@ public class lilToonSetting : ScriptableObject
         CheckTexture(ref shaderSetting.LIL_FEATURE_Emission2ndBlendMask      , "_Emission2ndBlendMask", material);
         CheckTexture(ref shaderSetting.LIL_FEATURE_Emission2ndGradTex        , "_Emission2ndGradTex", material);
         CheckTexture(ref shaderSetting.LIL_FEATURE_ParallaxMap               , "_ParallaxMap", material);
+        CheckTexture(ref shaderSetting.LIL_FEATURE_DistanceFadeMask          , "_DistanceFadeMask", material);
         CheckTexture(ref shaderSetting.LIL_FEATURE_AudioLinkMask             , "_AudioLinkMask", material);
         CheckTexture(ref shaderSetting.LIL_FEATURE_AudioLinkLocalMap         , "_AudioLinkLocalMap", material);
         CheckTexture(ref shaderSetting.LIL_FEATURE_DissolveMask              , "_DissolveMask", material);
@@ -1485,6 +1490,7 @@ public class lilToonSetting : ScriptableObject
         shaderSetting.LIL_FEATURE_Emission2ndBlendMask       = shaderSetting.LIL_FEATURE_Emission2ndBlendMask     || propname.Contains("_Emission2ndBlendMask");
         shaderSetting.LIL_FEATURE_Emission2ndGradTex         = shaderSetting.LIL_FEATURE_Emission2ndGradTex       || propname.Contains("_Emission2ndGradTex");
         shaderSetting.LIL_FEATURE_ParallaxMap                = shaderSetting.LIL_FEATURE_ParallaxMap              || propname.Contains("_ParallaxMap");
+        shaderSetting.LIL_FEATURE_DistanceFadeMask           = shaderSetting.LIL_FEATURE_DistanceFadeMask         || propname.Contains("_DistanceFadeMask");
         shaderSetting.LIL_FEATURE_AudioLinkMask              = shaderSetting.LIL_FEATURE_AudioLinkMask            || propname.Contains("_AudioLinkMask");
         shaderSetting.LIL_FEATURE_AudioLinkLocalMap          = shaderSetting.LIL_FEATURE_AudioLinkLocalMap        || propname.Contains("_AudioLinkLocalMap");
         shaderSetting.LIL_FEATURE_DissolveMask               = shaderSetting.LIL_FEATURE_DissolveMask             || propname.Contains("_DissolveMask");

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -2015,10 +2015,11 @@
     {
         float depth = _DistanceFadeMode ? fd.depthObject : fd.depth;
         float distFade = saturate((depth - _DistanceFade.x) / (_DistanceFade.y - _DistanceFade.x));
+        float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
         #if defined(LIL_OUTLINE) || defined(LIL_PASS_FORWARD_FUR_INCLUDED)
-            distFade = distFade * _DistanceFade.z;
+            distFade = distFade * distFadeStrength;
         #else
-            distFade = fd.facing < (_DistanceFade.w-1.0) ? _DistanceFade.z : distFade * _DistanceFade.z;
+            distFade = fd.facing < (_DistanceFade.w-1.0) ? distFadeStrength : distFade * distFadeStrength;
         #endif
         #if LIL_RENDER == 1
             fd.col.a = lerp(fd.col.a, fd.col.a * _DistanceFadeColor.a, distFade);
@@ -2029,10 +2030,11 @@
     {
         float depth = _DistanceFadeMode ? fd.depthObject : fd.depth;
         float distFade = saturate((depth - _DistanceFade.x) / (_DistanceFade.y - _DistanceFade.x));
+        float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
         #if defined(LIL_OUTLINE) || defined(LIL_PASS_FORWARD_FUR_INCLUDED)
-            distFade = distFade * _DistanceFade.z;
+            distFade = distFade * distFadeStrength;
         #else
-            distFade = fd.facing < (_DistanceFade.w-1.0) ? _DistanceFade.z : distFade * _DistanceFade.z;
+            distFade = fd.facing < (_DistanceFade.w-1.0) ? distFadeStrength : distFade * distFadeStrength;
         #endif
 
         float3 fadeColor = _DistanceFadeColor.rgb;

--- a/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_frag.hlsl
@@ -2015,7 +2015,11 @@
     {
         float depth = _DistanceFadeMode ? fd.depthObject : fd.depth;
         float distFade = saturate((depth - _DistanceFade.x) / (_DistanceFade.y - _DistanceFade.x));
-        float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
+        #if defined(LIL_FEATURE_DistanceFadeMask)
+            float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
+        #else
+            float distFadeStrength = _DistanceFade.z;
+        #endif
         #if defined(LIL_OUTLINE) || defined(LIL_PASS_FORWARD_FUR_INCLUDED)
             distFade = distFade * distFadeStrength;
         #else
@@ -2030,7 +2034,11 @@
     {
         float depth = _DistanceFadeMode ? fd.depthObject : fd.depth;
         float distFade = saturate((depth - _DistanceFade.x) / (_DistanceFade.y - _DistanceFade.x));
-        float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
+        #if defined(LIL_FEATURE_DistanceFadeMask)
+            float distFadeStrength = _DistanceFade.z * LIL_SAMPLE_2D(_DistanceFadeMask, lil_sampler_linear_repeat, fd.uvMain).r;
+        #else
+            float distFadeStrength = _DistanceFade.z;
+        #endif
         #if defined(LIL_OUTLINE) || defined(LIL_PASS_FORWARD_FUR_INCLUDED)
             distFade = distFade * distFadeStrength;
         #else

--- a/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_common_input.hlsl
@@ -876,6 +876,7 @@ TEXTURE2D(_Emission2ndBlendMask);
 TEXTURE2D(_Emission2ndGradTex);
 TEXTURE2D(_ParallaxMap);
 TEXTURE2D(_DitherTex);
+TEXTURE2D(_DistanceFadeMask);
 TEXTURE2D(_AudioLinkMask);
 TEXTURE2D(_AudioLinkLocalMap);
 TEXTURE2D(_DissolveMask);

--- a/Assets/lilToon/Shader/Includes/lil_replace_keywords.hlsl
+++ b/Assets/lilToon/Shader/Includes/lil_replace_keywords.hlsl
@@ -291,6 +291,7 @@
 #define LIL_FEATURE_Emission2ndBlendMask
 #define LIL_FEATURE_Emission2ndGradTex
 #define LIL_FEATURE_ParallaxMap
+#define LIL_FEATURE_DistanceFadeMask
 #define LIL_FEATURE_AudioLinkMask
 #define LIL_FEATURE_AudioLinkLocalMap
 #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts.shader
+++ b/Assets/lilToon/Shader/lts.shader
@@ -429,6 +429,7 @@ Shader "lilToon"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_cutout.shader
+++ b/Assets/lilToon/Shader/lts_cutout.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonCutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_cutout_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonCutoutOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_cutout_oo.shader
+++ b/Assets/lilToon/Shader/lts_cutout_oo.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyCutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_fakeshadow.shader
+++ b/Assets/lilToon/Shader/lts_fakeshadow.shader
@@ -143,6 +143,7 @@ Shader "_lil/[Optional] lilToonFakeShadow"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -752,6 +752,7 @@ Shader "Hidden/lilToonFur"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_fur.shader
+++ b/Assets/lilToon/Shader/lts_fur.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonFur"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonFurCutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_fur_cutout.shader
+++ b/Assets/lilToon/Shader/lts_fur_cutout.shader
@@ -752,6 +752,7 @@ Shader "Hidden/lilToonFurCutout"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonFurTwoPass"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_fur_two.shader
+++ b/Assets/lilToon/Shader/lts_fur_two.shader
@@ -752,6 +752,7 @@ Shader "Hidden/lilToonFurTwoPass"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_furonly.shader
+++ b/Assets/lilToon/Shader/lts_furonly.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_furonly_cutout.shader
+++ b/Assets/lilToon/Shader/lts_furonly_cutout.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonFurOnlyCutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_furonly_two.shader
+++ b/Assets/lilToon/Shader/lts_furonly_two.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonFurOnlyTwoPass"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonGem"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_gem.shader
+++ b/Assets/lilToon/Shader/lts_gem.shader
@@ -716,6 +716,7 @@ Shader "Hidden/lilToonGem"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_o.shader
+++ b/Assets/lilToon/Shader/lts_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_onetrans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonOnePassTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_onetrans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonOnePassTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_oo.shader
+++ b/Assets/lilToon/Shader/lts_oo.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonOutlineOnly"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_overlay.shader
+++ b/Assets/lilToon/Shader/lts_overlay.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonOverlay"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_overlay_one.shader
+++ b/Assets/lilToon/Shader/lts_overlay_one.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonOverlayOnePass"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -709,6 +709,7 @@ Shader "Hidden/lilToonRefraction"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_ref.shader
+++ b/Assets/lilToon/Shader/lts_ref.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonRefraction"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -709,6 +709,7 @@ Shader "Hidden/lilToonRefractionBlur"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/lts_ref_blur.shader
+++ b/Assets/lilToon/Shader/lts_ref_blur.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonRefractionBlur"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess.shader
+++ b/Assets/lilToon/Shader/lts_tess.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellation"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_cutout.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationCutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_cutout_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_cutout_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationCutoutOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_onetrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_onetrans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationOnePassTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_trans.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_trans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_tess_twotrans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTessellationTwoPassTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_trans.shader
+++ b/Assets/lilToon/Shader/lts_trans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_trans_o.shader
+++ b/Assets/lilToon/Shader/lts_trans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_trans_oo.shader
+++ b/Assets/lilToon/Shader/lts_trans_oo.shader
@@ -429,6 +429,7 @@ Shader "_lil/[Optional] lilToonOutlineOnlyTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_twotrans.shader
+++ b/Assets/lilToon/Shader/lts_twotrans.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTwoPassTransparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/lts_twotrans_o.shader
+++ b/Assets/lilToon/Shader/lts_twotrans_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonTwoPassTransparentOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltsmulti.shader
+++ b/Assets/lilToon/Shader/ltsmulti.shader
@@ -429,6 +429,7 @@ Shader "_lil/lilToonMulti"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltsmulti_fur.shader
+++ b/Assets/lilToon/Shader/ltsmulti_fur.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonMultiFur"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltsmulti_gem.shader
+++ b/Assets/lilToon/Shader/ltsmulti_gem.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonMultiGem"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltsmulti_o.shader
+++ b/Assets/lilToon/Shader/ltsmulti_o.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonMultiOutline"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltsmulti_ref.shader
+++ b/Assets/lilToon/Shader/ltsmulti_ref.shader
@@ -429,6 +429,7 @@ Shader "Hidden/lilToonMultiRefraction"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_baker.shader
+++ b/Assets/lilToon/Shader/ltspass_baker.shader
@@ -164,6 +164,7 @@ Shader "Hidden/ltsother_baker"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -731,6 +731,7 @@ Shader "Hidden/ltspass_cutout"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_cutout.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_cutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_opaque"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_opaque.shader
@@ -731,6 +731,7 @@ Shader "Hidden/ltspass_opaque"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_proponly.shader
+++ b/Assets/lilToon/Shader/ltspass_proponly.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_proponly"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_tess_cutout"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_tess_cutout.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_cutout.shader
@@ -731,6 +731,7 @@ Shader "Hidden/ltspass_tess_cutout"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -731,6 +731,7 @@ Shader "Hidden/ltspass_tess_opaque"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_tess_opaque.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_opaque.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_tess_opaque"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -764,6 +764,7 @@ Shader "Hidden/ltspass_tess_transparent"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask

--- a/Assets/lilToon/Shader/ltspass_tess_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_tess_transparent.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_tess_transparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -429,6 +429,7 @@ Shader "Hidden/ltspass_transparent"
         [lilHDR]        _DistanceFadeColor          ("sColor", Color) = (0,0,0,1)
         [lilFFFB]       _DistanceFade               ("sDistanceFadeSettings", Vector) = (0.1,0.01,0,0)
         [lilEnum]       _DistanceFadeMode           ("sDistanceFadeModes", Int) = 0
+        [NoScaleOffset] _DistanceFadeMask           ("Mask", 2D) = "white" {}
         [lilHDR]        _DistanceFadeRimColor       ("sColor", Color) = (0,0,0,0)
         [PowerSlider(3.0)]_DistanceFadeRimFresnelPower ("sFresnelPower", Range(0.01, 50)) = 5.0
 

--- a/Assets/lilToon/Shader/ltspass_transparent.shader
+++ b/Assets/lilToon/Shader/ltspass_transparent.shader
@@ -764,6 +764,7 @@ Shader "Hidden/ltspass_transparent"
             #define LIL_FEATURE_Emission2ndBlendMask
             #define LIL_FEATURE_Emission2ndGradTex
             #define LIL_FEATURE_ParallaxMap
+            #define LIL_FEATURE_DistanceFadeMask
             #define LIL_FEATURE_AudioLinkMask
             #define LIL_FEATURE_AudioLinkLocalMap
             #define LIL_FEATURE_DissolveMask


### PR DESCRIPTION
fix #390 
距離フェードに非二値マスクを追加します

<img width="626" height="365" alt="image" src="https://github.com/user-attachments/assets/63ae1714-1048-4779-b69d-5abd8eeafb56" />
