### PR TITLE
fix: lilPresetColor ensures that HDRColor is saved correctly

### DIFF
--- a/Assets/lilToon/Editor/lilToonPreset.cs
+++ b/Assets/lilToon/Editor/lilToonPreset.cs
@@ -33,6 +33,7 @@ public class lilToonPreset : ScriptableObject
     public struct lilPresetColor
     {
         public string name;
+        [ColorUsage(true, true)]
         public Color value;
     }
 


### PR DESCRIPTION
## 概要
lilToonPreset.csで宣言されるColorに対し、`[ColorUsage(true, true)]`属性を追加しました。

## 問題
MaterialProperty側ではHDR Colorに対応しているColor項目(_Color2nd, _RimColor, _BacklightColor, など)の情報をlilToonPresetに保存した際、lilToonPresetでは非HDR Colorとして保存されていました。

結果として、Intensityが保存されなくなるため、露出が低く、くすんだ色として適用されていました。