### PR TITLE
fix: The feature that "Removes unused properties" is accidentally removing the mask for AudioLink #423

### DIFF
--- a/Assets/lilToon/Editor/lilMaterialUtils.cs
+++ b/Assets/lilToon/Editor/lilMaterialUtils.cs
@@ -660,7 +660,13 @@ namespace lilToon
                 if(IsPropZero(material, "_UseRim", animatedProps)) material.SetTexture("_RimColorTex", null);
                 if(IsPropZero(material, "_UseGlitter", animatedProps)) material.SetTexture("_GlitterColorTex", null);
                 if(IsPropZero(material, "_UseParallax", animatedProps)) material.SetTexture("_ParallaxMap", null);
-                if(IsPropZero(material, "_UseAudioLink", animatedProps) || material.GetFloat("_AudioLinkUVMode") != 3.0f || animatedProps.Contains("_AudioLinkUVMode")) material.SetTexture("_AudioLinkMask", null);
+                if(IsPropZero(material, "_UseAudioLink", animatedProps) || (
+                    (material.GetFloat("_AudioLinkUVMode") != 3.0f || animatedProps.Contains("_AudioLinkUVMode"))
+                    && (material.GetFloat("_AudioLinkVertexUVMode") != 3.0f || animatedProps.Contains("_AudioLinkVertexUVMode"))
+                ))
+                {
+                    material.SetTexture("_AudioLinkMask", null);
+                }
                 if(IsPropZero(material, "_UseAudioLink", animatedProps) || IsPropZero(material, "_AudioLinkAsLocal", animatedProps)) material.SetTexture("_AudioLinkLocalMap", null);
             }
         }


### PR DESCRIPTION
#423 の修正です．

未使用テクスチャを除去する処理にて，プロパティの値から未使用テクスチャを判定して除去するようになっていますが，
 [`_AudioLinkMask` の使用有無を `_AudioLinkUVMode` からのみ判定](https://github.com/lilxyzw/lilToon/blob/2.3.4/Assets/lilToon/Editor/lilMaterialUtils.cs#L663 "Assets/lilToon/Editor/lilMaterialUtils.cs")していたため，頂点のUV Mode（`_AudioLinkVertexUVMode`）で「マスク」を指定していても，マスクが除去されることがありました． 

---

- fix: #423