### PR TITLE
fix: UI Toolkitアセットを含むシーンのビルドでメモリ確保に失敗しクラッシュする問題を修正

### DIFF
--- a/Assets/lilToon/Editor/lilToon.Editor.asmdef
+++ b/Assets/lilToon/Editor/lilToon.Editor.asmdef
@@ -41,6 +41,11 @@
             "name": "com.llealloo.audiolink",
             "expression": "2",
             "define": "LILTOON_AUDIOLINK"
+        },
+        {
+            "name": "com.unity.modules.uielements",
+            "expression": "",
+            "define": "LILTOON_MODULE_UIELEMENTS"
         }
     ],
     "noEngineReferences": false

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -794,9 +794,11 @@ public class lilToonSetting : ScriptableObject
                 next is Shader ||
                 next is TextAsset ||
                 next is UnityEngine.Font ||
+#if LILTOON_MODULE_UIELEMENTS
                 next is UnityEngine.UIElements.VisualTreeAsset ||
                 next is UnityEngine.UIElements.StyleSheet ||
                 next is UnityEngine.UIElements.PanelSettings ||
+#endif
                 next.GetType() == typeof(Object)
             ) continue;
 

--- a/Assets/lilToon/Editor/lilToonSetting.cs
+++ b/Assets/lilToon/Editor/lilToonSetting.cs
@@ -793,6 +793,10 @@ public class lilToonSetting : ScriptableObject
                 next is Texture ||
                 next is Shader ||
                 next is TextAsset ||
+                next is UnityEngine.Font ||
+                next is UnityEngine.UIElements.VisualTreeAsset ||
+                next is UnityEngine.UIElements.StyleSheet ||
+                next is UnityEngine.UIElements.PanelSettings ||
                 next.GetType() == typeof(Object)
             ) continue;
 


### PR DESCRIPTION
Fixes #404
（関連：#413 も同じ走査処理に関する指摘ですが、本PRはUI Toolkitアセットで走査が発散しメモリを食い尽くすケースへの対処です）

## 症状
UIDocument（VisualTreeAsset / StyleSheet / PanelSettings / Font を参照）を含むシーンをビルド対象に含めてプレイヤービルドを実行すると、ビルド時のシェーダー最適化処理でメモリ使用量が数十GB規模まで膨張し、Unityが Fatal Error（ALLOC_DEFAULT の確保失敗）でクラッシュします。当方の環境では約97GB→160GBの確保を試みて失敗しました。UI Toolkitを含むシーンをビルドから外すと正常にビルドできます。

## 原因
`lilToonSetting.cs` の `WalkAllSceneReferencedAssets` がシーンから参照されるアセットを `SerializedProperty.Next(enterChildren: true)` で再帰走査する際、UI Toolkit系アセットがskip対象に含まれておらず、内部プロパティの走査が発散するためです。

## 修正内容
走査のskip条件に UnityEngine.Font / VisualTreeAsset / StyleSheet / PanelSettings を追加しました（ThemeStyleSheetはStyleSheetの派生として吸収されます）。これらのアセットがlilToonシェーダーのマテリアル参照を含むことは実質的にないため、走査対象から外して問題ないと考えています。
(追記)
uielementsモジュールを無効化しているプロジェクトでもコンパイルエラーにならないよう、UIElements系の型チェックは Version Define（`com.unity.modules.uielements` → `LILTOON_MODULE_UIELEMENTS`）でガードしています。
`UnityEngine.Font` は常設の TextRenderingModule 所属（無効化手段となるビルトインパッケージが存在しない）ため、ガード不要と判断しています。

## 検証環境
- Unity 6000.3.10f1 / URP / lilToon 2.3.3
- 修正前：UI Toolkitシーンを含むビルドで100%クラッシュ
- 修正後：同構成で正常にビルド完了（シェーダー最適化の動作も確認）
